### PR TITLE
Fix crash when command_set_parser is not defined

### DIFF
--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -66,6 +66,8 @@ class ZwaveDriver extends events.EventEmitter {
 					} else {
 						var instance = node.instance;
 					}
+					
+					if( typeof options_capability_item.command_set_parser !== 'function' ) return;
 
 					var args = options_capability_item.command_set_parser( value, node );
 


### PR DESCRIPTION
Add check to see if command_set_parser is undefined, when it is it will abort.