### PR TITLE
flip boolean parser

### DIFF
--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -168,7 +168,7 @@ class ZwaveDriver extends events.EventEmitter {
 
 				} else if( typeof newSettingsObj[ changedKey ] === 'boolean' ) {
 
-					var newValue = new Buffer([ ( newSettingsObj[ changedKey ] === true ) ? 0 : 1 ]);
+					var newValue = new Buffer([ ( newSettingsObj[ changedKey ] === true ) ? 1 : 0 ]);
 
 				}
 


### PR DESCRIPTION
this makes 99.5% of the (boolean) driver parsers not needed.