### PR TITLE
add noParameter function

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ module.exports = new ZwaveDriver('mydriver', {
 			// set signed to false to let (0, 255) scale to (0x00, 0xFF)
 			// otherwise the domain is (-128, 127) for size=1
 			'signed': false
+		},
+		'internalSetting': {
+
+			// If the setting is for internal driver use and not a parameter
+			'noParameter': function( input ) {
+				// Run your code here
+			}
 		}
 	}
 });

--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -213,7 +213,13 @@ class ZwaveDriver extends events.EventEmitter {
 				let newValue = undefined;
 
 				// Magically try to convert the value to a buffer
-				if (typeof settingsObj.parser === 'function') {
+				if (typeof settingsObj.noParameter === 'function') {
+					
+					// If noParameter is used, pass on the value and continue
+					settingsObj.noParameter(newSettingsObj[changedKey]);
+					continue;
+					
+				} else if (typeof settingsObj.parser === 'function') {
 
 					// Use the parser defined in driver.js and feed it the newly saved setting
 					newValue = settingsObj.parser(newSettingsObj[changedKey], newSettingsObj);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homey-zwavedriver",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Generic class to map Z-Wave CommandClasses to Homey capabilities",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
i need a setting of the device only in the driver, and it is not a parameter.

since it might happen more often i though of implementing it in the z-wave driver.
what do you think if this implementation?

there is a workaround with taking out the setting from the setting array, but found that a too "hacky" kind of way.