### PR TITLE
Only send configuration and GET commands if device sent WAKE_UP_NOTIFICATION

### DIFF
--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -594,13 +594,10 @@ class ZwaveDriver extends events.EventEmitter {
 						};
 
 						if (typeof optionsCapabilityItem.getOnWakeUp === "string" && optionsCapabilityItem.getOnWakeUp === 'afterWakeUpNotificationOnly' && node.instance.CommandClass.hasOwnProperty('COMMAND_CLASS_WAKE_UP')) {
-							this._debug('Scheduling get command when COMMAND_CLASS_WAKE_UP happens', optionsCapabilityItem)
 							node.instance.CommandClass.COMMAND_CLASS_WAKE_UP.on('report', () => {
-								this._debug('Calling get command for', capabilityId)
 								get.call(this);
 							});
 						} else {
-							this._debug(optionsCapabilityItem.getOnWakeUp)
 							// Call the get defined above
 							get.call(this);
 						}

--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -280,7 +280,7 @@ class ZwaveDriver extends events.EventEmitter {
 		});
 
 		// Provide user with proper feedback after clicking save
-		if (node.instance.battery === true && node.instance.online === false) {
+		if (node.instance.battery === true && (node.instance.online === false || (this.options.setConfigurationMethod === 'wakeUpNotification' && node.instance.CommandClass.hasOwnProperty('COMMAND_CLASS_WAKE_UP')))) {
 			callback(null, {
 				en: 'Settings will be saved during the next wakeup of this battery device.',
 				nl: 'Instelling zullen worden opgeslagen bij volgende wakeup van dit apparaat'

--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -26,6 +26,7 @@ class ZwaveDriver extends events.EventEmitter {
 			debug: false,
 			beforeInit: false,
 			capabilities: {},
+			setConfigurationMethod: 'immediate',
 		}, options);
 
 		this.nodes = {};
@@ -252,17 +253,26 @@ class ZwaveDriver extends events.EventEmitter {
 					this._debug('CONFIGURATION_SET', 'index:', settingsObj.index, 'size:', settingsObj.size,
 						'newValue', newValue);
 
-					// Call configuration set on node with new value
-					node.instance.CommandClass.COMMAND_CLASS_CONFIGURATION.CONFIGURATION_SET({
-						'Parameter Number': settingsObj.index,
-						Level: {
-							Size: settingsObj.size,
-							Default: false,
-						},
-						'Configuration Value': newValue,
-					}, (err, result) => {
-						if (err) return this._debug('CONFIGURATION_SET', err);
-					});
+					let configurationSet = function() {
+						// Call configuration set on node with new value
+						node.instance.CommandClass.COMMAND_CLASS_CONFIGURATION.CONFIGURATION_SET({
+							'Parameter Number': settingsObj.index,
+							Level: {
+								Size: settingsObj.size,
+								Default: false,
+							},
+							'Configuration Value': newValue,
+						}, (err, result) => {
+							if (err) return this._debug('CONFIGURATION_SET', err);
+						});
+					}
+					if (this.options.setConfigurationMethod === 'wakeUpNotification' && node.instance.CommandClass.hasOwnProperty('COMMAND_CLASS_WAKE_UP')) {
+						node.instance.CommandClass.COMMAND_CLASS_WAKE_UP.once('report', () => {
+							configurationSet();
+						})
+					} else {
+						configurationSet();
+					}
 				} else {
 					this._debug('invalid new value for setting', changedKey);
 				}
@@ -583,11 +593,20 @@ class ZwaveDriver extends events.EventEmitter {
 							}, pollInterval);
 						};
 
-						// Call the get defined above
-						get.call(this);
+						if (typeof optionsCapabilityItem.getOnWakeUp === "string" && optionsCapabilityItem.getOnWakeUp === 'afterWakeUpNotificationOnly' && node.instance.CommandClass.hasOwnProperty('COMMAND_CLASS_WAKE_UP')) {
+							this._debug('Scheduling get command when COMMAND_CLASS_WAKE_UP happens', optionsCapabilityItem)
+							node.instance.CommandClass.COMMAND_CLASS_WAKE_UP.on('report', () => {
+								this._debug('Calling get command for', capabilityId)
+								get.call(this);
+							});
+						} else {
+							this._debug(optionsCapabilityItem.getOnWakeUp)
+							// Call the get defined above
+							get.call(this);
+						}
 
 						// If getOnWakeUp is set in driver.js
-						if (optionsCapabilityItem.getOnWakeUp) {
+						if (optionsCapabilityItem.getOnWakeUp && typeof optionsCapabilityItem.getOnWakeUp === "boolean") {
 							zwaveNode.on('online', online => {
 								if (online) get.call(this);
 							});

--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -2,7 +2,7 @@
 
 const events = require('events');
 
-const nodeEvents = ['online', 'applicationUpdate'];
+const nodeEvents = ['online', 'applicationUpdate', 'awake'];
 
 /**
  * Generic driver for Z-Wave devices.
@@ -26,7 +26,7 @@ class ZwaveDriver extends events.EventEmitter {
 			debug: false,
 			beforeInit: false,
 			capabilities: {},
-			setConfigurationMethod: 'immediate',
+			awakeMode: 'online'
 		}, options);
 
 		this.nodes = {};
@@ -252,8 +252,8 @@ class ZwaveDriver extends events.EventEmitter {
 				if (Buffer.isBuffer(newValue)) {
 					this._debug('CONFIGURATION_SET', 'index:', settingsObj.index, 'size:', settingsObj.size,
 						'newValue', newValue);
-
 					let configurationSet = function() {
+						this._debug('Running CONFIGURATION_SET for index:', settingsObj.index);
 						// Call configuration set on node with new value
 						node.instance.CommandClass.COMMAND_CLASS_CONFIGURATION.CONFIGURATION_SET({
 							'Parameter Number': settingsObj.index,
@@ -265,11 +265,11 @@ class ZwaveDriver extends events.EventEmitter {
 						}, (err, result) => {
 							if (err) return this._debug('CONFIGURATION_SET', err);
 						});
-					}
-					if (this.options.setConfigurationMethod === 'wakeUpNotification' && node.instance.CommandClass.hasOwnProperty('COMMAND_CLASS_WAKE_UP')) {
-						node.instance.CommandClass.COMMAND_CLASS_WAKE_UP.once('report', () => {
-							configurationSet();
-						})
+					}.bind(this)
+					if (node.instance.hasWakeUp) {
+						node.instance.once('awake', awake => {
+							if (awake) configurationSet();
+						});
 					} else {
 						configurationSet();
 					}
@@ -280,7 +280,7 @@ class ZwaveDriver extends events.EventEmitter {
 		});
 
 		// Provide user with proper feedback after clicking save
-		if (node.instance.battery === true && (node.instance.online === false || (this.options.setConfigurationMethod === 'wakeUpNotification' && node.instance.CommandClass.hasOwnProperty('COMMAND_CLASS_WAKE_UP')))) {
+		if (node.instance.battery === true && (node.instance.online === false || node.instance.hasWakeUp === true)) {
 			callback(null, {
 				en: 'Settings will be saved during the next wakeup of this battery device.',
 				nl: 'Instelling zullen worden opgeslagen bij volgende wakeup van dit apparaat'
@@ -399,6 +399,17 @@ class ZwaveDriver extends events.EventEmitter {
 							}.bind(this));
 						});
 					});
+				}
+
+				zwaveNode.hasWakeUp = false; // Let the driver decide if we use the awake notification
+				if (zwaveNode.CommandClass.hasOwnProperty('COMMAND_CLASS_WAKE_UP') && this.options.awakeMode === 'awake') {
+					zwaveNode.hasWakeUp = true;
+					zwaveNode.CommandClass['COMMAND_CLASS_WAKE_UP'].on('report', function (report) {
+						if (report.name == 'WAKE_UP_NOTIFICATION') {
+							this._debug('emitting awake thru WAKE_UP_NOTIFICATION');
+							zwaveNode.emit('awake', true);
+						}
+					}.bind(this));
 				}
 			}
 
@@ -593,20 +604,21 @@ class ZwaveDriver extends events.EventEmitter {
 							}, pollInterval);
 						};
 
-						if (typeof optionsCapabilityItem.getOnWakeUp === "string" && optionsCapabilityItem.getOnWakeUp === 'afterWakeUpNotificationOnly' && node.instance.CommandClass.hasOwnProperty('COMMAND_CLASS_WAKE_UP')) {
-							node.instance.CommandClass.COMMAND_CLASS_WAKE_UP.on('report', () => {
-								get.call(this);
-							});
-						} else {
-							// Call the get defined above
+						// Call the get defined above
+						if (! (zwaveNode.hasWakeUp && optionsCapabilityItem.getOnWakeUp))
 							get.call(this);
-						}
 
 						// If getOnWakeUp is set in driver.js
-						if (optionsCapabilityItem.getOnWakeUp && typeof optionsCapabilityItem.getOnWakeUp === "boolean") {
-							zwaveNode.on('online', online => {
-								if (online) get.call(this);
-							});
+						if (optionsCapabilityItem.getOnWakeUp) {
+							if (zwaveNode.hasWakeUp) {
+								zwaveNode.on('awake', awake => {
+									if (awake) get.call(this);
+								});
+							} else {
+								zwaveNode.on('online', online => {
+									if (online) get.call(this);
+								});
+							}
 						}
 
 						// If pollInterval is set in driver.js


### PR DESCRIPTION
My Z-Wave device (TKB Home TSP01; tamper,motion,temp,luminance sensor), is only capable of responding to GET/CONFIGURATION commands, if it is actually awake. And by awake, i mean if the device has sent the WAKE_UP_NOTIFICATION command.

Otherwise you will get errors like this, but without a report being sent back:
```[debug]  COMMAND_CLASS_SENSOR_BINARY SENSOR_BINARY_GET args: { 'Sensor Type': 'Door/Window' } err: { [Error: TRANSMIT_COMPLETE_NO_ACK] message: 'TRANSMIT_COMPLETE_NO_ACK' } result: null```

Also, if a GET command is pending a report, and in the meantime a motion event is triggered, it will might get misplaced at a different capability which is also using the SENSOR_BINARY_GET report.

So for example, the alarm_tamper capability has sent a SENSOR_BINARY_GET command (with the correct params...), then when a motion event has triggered (which is separately configured as a alarm_motion capability with the same SENSOR_BINARY) the report ends up with the alarm_tamper, as the report type class is the same for both.

In normal situations this is not an issue, as the report is sent to all capabilities who are subscribed to that report-class.

The proposed fix (which might be better placed in the Z-Wave core of Homey) fixes this for my device, if i set the correct variables in my TSP01 driver.
Because i don't know if the COMMAND_CLASS_WAKE_UP works the same for every device, i made a configuration item for it.
Another approach might be to change the 'online' event, as this sensor was marked as online (because it was sending data), but it was not possible to send data to the device during this time, as this is only possible if the device is actually awake.