### PR TITLE
add custom setting function

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ module.exports = new ZwaveDriver('mydriver', {
 			'size': 1,
 			
 			// define a custom parser method (optional)
-			'parser': function( input ) {
-				return new Buffer([ parseInt(input) ]);
+			'parser': function( newValue, newSettings, deviceData ) {
+				return new Buffer([ parseInt(newValue) ]);
 			}
 		},
 		'led_ring_color_off': {
@@ -77,6 +77,10 @@ module.exports = new ZwaveDriver('mydriver', {
 			// set signed to false to let (0, 255) scale to (0x00, 0xFF)
 			// otherwise the domain is (-128, 127) for size=1
 			'signed': false
+		},
+		'custom_setting': function( newValue, oldValue, deviceData ) {
+
+			// For using a custom setting in the driver
 		}
 	}
 });

--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -220,11 +220,17 @@ class ZwaveDriver extends events.EventEmitter {
 
 				let newValue = undefined;
 
+				// If settings object is a function return value in the driver
+				if (typeof settingsObj === 'function') {
+					
+					settingsObj(newSettingsObj[changedKey], oldSettingsObj[changedKey], deviceData);
+					continue;
+
 				// Magically try to convert the value to a buffer
-				if (typeof settingsObj.parser === 'function') {
+				} else if (typeof settingsObj.parser === 'function') {
 
 					// Use the parser defined in driver.js and feed it the newly saved setting
-					newValue = settingsObj.parser(newSettingsObj[changedKey], newSettingsObj);
+					newValue = settingsObj.parser(newSettingsObj[changedKey], newSettingsObj, deviceData);
 
 					// Check if valid buffer is provided
 					if (!Buffer.isBuffer(newValue)) throw new Error(`invalid_setting_value_type_for_${changedKey}`);
@@ -233,7 +239,7 @@ class ZwaveDriver extends events.EventEmitter {
 					|| parseInt(newSettingsObj[changedKey], 10).toString() === newSettingsObj[changedKey]) {
 
 					// Try to write new value  to a buffer
-					if( settingsObj.signed === false ) {
+					if (settingsObj.signed === false) {
 
 						try {
 							newValue = new Buffer(settingsObj.size);


### PR DESCRIPTION
added/changed the custom setting function like emile proposed.

also added the deviceData object into the `parser` function, to be able to use the device token in the parser.

Example use case for the deviceData object in the `parser` function (i wanted to use it for):
the fibaro dimmer 2 auto updates a setting internally after being done with calibration, now it is easy making it visible into homey as well with a time-out to the new (auto changed) value.