### PR TITLE
Allow debugging when debug file/dir is found in driver directory

### DIFF
--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const events = require('events');
+const fs = require('fs');
 
 const nodeEvents = ['online', 'applicationUpdate'];
 
@@ -23,6 +24,10 @@ class ZwaveDriver extends events.EventEmitter {
 		// Get driver specification as defined in app.json
 		this.driverId = driverId;
 		this.driver = findWhere(Homey.manifest.drivers, { id: driverId });
+		// set debug to true when debug is found in driver directory
+		if (fs.existsSync('/drivers/' + driverId + '/debug')) {
+			options.debug = true;
+		}
 
 		// Override default options with provided options object
 		this.options = Object.assign({


### PR DESCRIPTION
I always have to think about remove debug option from my zwave driver when I want to create a new release. With this option it would be possible to just create the file local and add it to my gitignore file and dont worry about it anymore.

I initially tried it with .debug but it seems athom-cli does not upload hidden files.