### PR TITLE
Replace hardcoded pollInterval name

### DIFF
--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -215,7 +215,7 @@ class ZwaveDriver extends events.EventEmitter {
 			// Store changed setting in node object
 			node.settings[changedKey] = newSettingsObj[changedKey];
 
-			if (changedKey === 'poll_interval') {
+			if (changedKey.startsWith('poll_interval')) {
 
 				// Loop over all setPollIntervals and call them with the newly saved value
 				Object.keys(this.nodes[deviceData.token].setPollIntervals).forEach(capabilityId => {
@@ -644,7 +644,7 @@ class ZwaveDriver extends events.EventEmitter {
 								this.nodes[deviceData.token].setPollIntervals[capabilityId].call(this,
 									optionsCapabilityItem.pollInterval);
 
-							} else if (optionsCapabilityItem.pollInterval === 'poll_interval') {
+							} else if (optionsCapabilityItem.pollInterval.startsWith('poll_interval')) {
 
 								// Get poll interval value from settings
 								this.getSettings(deviceData, (err, settings) => {


### PR DESCRIPTION
Replace of hardcoded pollInterval name 'poll_interval' to enable differentiation of polling interval for devices using polling on multiple capabilities (e.g. Greenwave powernodes).

Replaced by `startsWith('poll_interval')` check to still be able to differentiate polling interval from settings

Tested for 2 weeks on setup with 5 powernode-6's and 1 powernode-1; working OK and reducing the amount of queue_full errors substantially.