### PR TITLE
[dea] custom saveSettingMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,15 @@ module.exports = new ZwaveDriver('mydriver', {
 			// For using a custom setting in the driver
 		}
 	},
-	settingsSaveMessage: {
-		// If the device needs a specific way of waking up so parameters can be send,
-		// you can provide your own message when the user presses save.
+	// If the device needs a specific way of waking up so parameters can be send,
+	// you can create your own message as a dynamic function or static object, when the user presses save.
+	'customSaveMessage': function ( newSettings, oldSettings, changedKeysArr, deviceData ) {
+		// Your magic for creating a dynamic settings save message
+		return {
+			'en': 'Your wake up message'
+		}
+	}
+	'customSaveMessage': {
 		'en': 'Your wake up message'
 	}
 });

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ module.exports = new ZwaveDriver('mydriver', {
 		'led_ring_color_on': {
 			'index': 61,
 			'size': 1,
-			
+
 			// define a custom parser method (optional)
 			'parser': function( newValue, newSettings, deviceData ) {
 				return new Buffer([ parseInt(newValue) ]);
@@ -76,7 +76,7 @@ module.exports = new ZwaveDriver('mydriver', {
 		'sensitivity': {
 			'index': 63,
 			'size': 1,
-			
+
 			// set signed to false to let (0, 255) scale to (0x00, 0xFF)
 			// otherwise the domain is (-128, 127) for size=1
 			'signed': false
@@ -85,6 +85,11 @@ module.exports = new ZwaveDriver('mydriver', {
 
 			// For using a custom setting in the driver
 		}
+	},
+	settingsSaveMessage: {
+		// If the device needs a specific way of waking up so parameters can be send,
+		// you can provide your own message when the user presses save.
+		'en': 'Your wake up message'
 	}
 });
 ```

--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -295,8 +295,8 @@ class ZwaveDriver extends events.EventEmitter {
 
 		// Provide user with proper feedback after clicking save
 		if (node.instance.battery === true && node.instance.online === false) {
-			if (typeof this.driver.zwave.saveSettingMessage !== 'undefined' && this.driver.zwave.saveSettingMessage.hasOwnProperty('en')) {
-				return callback(null, this.driver.zwave.saveSettingMessage);
+			if (typeof this.options.settingsSaveMessage !== 'undefined' && this.options.settingsSaveMessage.hasOwnProperty('en')) {
+				return callback(null, this.options.settingsSaveMessage);
 			} else {
 				return callback(null, {
 					en: 'Settings will be saved during the next wakeup of this battery device.',

--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -295,10 +295,14 @@ class ZwaveDriver extends events.EventEmitter {
 
 		// Provide user with proper feedback after clicking save
 		if (node.instance.battery === true && node.instance.online === false) {
-			callback(null, {
-				en: 'Settings will be saved during the next wakeup of this battery device.',
-				nl: 'Instelling zullen worden opgeslagen bij volgende wakeup van dit apparaat'
-			});
+			if (typeof this.driver.zwave.saveSettingMessage !== 'undefined' && this.driver.zwave.saveSettingMessage.hasOwnProperty('en')) {
+				return callback(null, this.driver.zwave.saveSettingMessage);
+			} else {
+				return callback(null, {
+					en: 'Settings will be saved during the next wakeup of this battery device.',
+					nl: 'Instelling zullen worden opgeslagen bij volgende wakeup van dit apparaat'
+				});
+			}
 		} else {
 			return callback(null, true);
 		}

--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -295,14 +295,31 @@ class ZwaveDriver extends events.EventEmitter {
 
 		// Provide user with proper feedback after clicking save
 		if (node.instance.battery === true && node.instance.online === false) {
-			if (typeof this.options.settingsSaveMessage !== 'undefined' && this.options.settingsSaveMessage.hasOwnProperty('en')) {
-				return callback(null, this.options.settingsSaveMessage);
-			} else {
-				return callback(null, {
-					en: 'Settings will be saved during the next wakeup of this battery device.',
-					nl: 'Instelling zullen worden opgeslagen bij volgende wakeup van dit apparaat'
-				});
+			let saveMessage = {
+				en: 'Settings will be saved during the next wakeup of this battery device.',
+				nl: 'Instelling zullen worden opgeslagen bij volgende wakeup van dit apparaat'
 			}
+
+			if (typeof this.options.customSaveMessage === 'function') {
+				let message = this.options.customSaveMessage(newSettingsObj, oldSettingsObj, changedKeysArr, deviceData);
+
+				if (typeof message !== 'object') {
+					this._debug('Save message\'s return value is an invalid object');
+				} else if (!message.hasOwnProperty('en')) {
+					this._debug('A custom save message needs at least the english translation');
+				} else {
+					saveMessage = message;
+				}
+
+			} else if (typeof this.options.customSaveMessage === 'object') {
+				if (!this.options.customSaveMessage.hasOwnProperty('en')) {
+					this._debug('A custom save message needs at least the english translation');
+				} else {
+					saveMessage = this.options.customSaveMessage;
+				}
+
+			}
+			return callback(null, saveMessage);
 		} else {
 			return callback(null, true);
 		}


### PR DESCRIPTION
There are certain devices that would really benefit of a custom save Setting Message.
Like the Fibaro Keyfob,
who only wakes up enough in/for homey when using the NIF send sequence.
(which is different from what is in the manual)
And people... just don't read the readme file, this is a bit more in to their face.

Since it's probably something only for z-wave,
I have chosen to put it in the zwave object,
and does work without having to re-pair the device.

I'll see if you agree on this idea, and/or if you would like to change something.