### PR TITLE
Fix offline battery device command_set execution

### DIFF
--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -119,6 +119,24 @@ class ZwaveDriver extends events.EventEmitter {
 					this._debug(optionsCapabilityItem.multiChannelNodeId || '', `${optionsCapabilityItem.command_class}
 					->${optionsCapabilityItem.command_set}`, 'args:', args);
 
+					// If battery device and asleep return callback immediately since the set will be performed
+					// at an unknown moment in the future
+					if (node.instance.battery === true && node.instance.online === false) {
+						this._debug(`device is offline, set will occur on wake up`);
+
+						// Update value in state object
+						node.state[capabilityId] = value;
+
+						// Emit realtime event
+						this.realtime(deviceData, capabilityId, value);
+
+						// Call callback as if the set were successful
+						callback(null, node.state[capabilityId]);
+
+						// Prevent callback from being called twice
+						callback = function(){};
+					}
+
 					// Perform the command set on the node
 					instance.CommandClass[optionsCapabilityItem.command_class][optionsCapabilityItem.command_set](args,
 						(err, result) => {

--- a/lib/ZwaveDriver.js
+++ b/lib/ZwaveDriver.js
@@ -122,7 +122,7 @@ class ZwaveDriver extends events.EventEmitter {
 					// If battery device and asleep return callback immediately since the set will be performed
 					// at an unknown moment in the future
 					if (node.instance.battery === true && node.instance.online === false) {
-						this._debug(`device is offline, set will occur on wake up`);
+						this._debug(`device is offline, ${optionsCapabilityItem.command_set} will be executed when devices comes online`);
 
 						// Update value in state object
 						node.state[capabilityId] = value;


### PR DESCRIPTION
When a capability set is executed on a sleeping battery device the command will be put in a queue which is emptied when the device comes online. This was not a problem previously, but with the new smartphone app the user gets presented a timeout error after 5 seconds. Therefore, the capability set will now immediately return its callback as if the command was executed successfully. 