### PR TITLE
docs: update getOnOnline and getOnStart docs

### DIFF
--- a/examples/fibaroplug.js
+++ b/examples/fibaroplug.js
@@ -22,9 +22,10 @@ class FibaroPlugDevice extends ZwaveDevice {
     // capability handler
     this.registerCapability('onoff', 'SWITCH_BINARY', {
       getOpts: {
+        // Only use these options when a device doesn't automatically report its values
         getOnStart: true, // get the initial value on app start (only use for non-battery devices)
-        pollInterval: 'poll_interval', // maps to device settings
         // getOnOnline: true, // use only for battery devices
+        pollInterval: 'poll_interval', // maps to device settings
       },
       getParserV3: (value, opts) => ({}),
     });

--- a/lib/ZwaveDevice.js
+++ b/lib/ZwaveDevice.js
@@ -353,11 +353,10 @@ class ZwaveDevice extends Homey.Device {
       // But not for battery devices
       if (this.node.battery === false) {
         this._getCapabilityValue(capabilityId, commandClassId).catch(err => this.error(`Could not get capability value for capabilityId: ${capabilityId}`, err));
-      } else this.error('do not use getOnStart for battery devices, use getOnOnline instead');
+      } else this.error('do not use getOnStart for battery devices');
     }
 
-    // Perform get on online, also when device is initing and device is still online (replacing
-    // the getOnStart functionality)
+    // Perform get on online, also when device is initing and device is still online
     if (capabilityGetObj.opts.getOnOnline) {
       // Get immediately if node is still online (right after pairing for example)
       if (this.node.battery === true && this.node.online === true) {
@@ -701,9 +700,11 @@ class ZwaveDevice extends Homey.Device {
    * @param {String} [userOpts.getParser] - The function that is called when a GET request is
    * made. Should return an Object.
    * @param {Object} [userOpts.getOpts
-   * @param {Boolean} [userOpts.getOpts.getOnStart] - Get the value on App start.
-   * @param {Boolean} [userOpts.getOpts.getOnOnline] - Get the value when the device is marked
-   * as online.
+   * @param {Boolean} [userOpts.getOpts.getOnStart] - Get the value on App start. Avoid using this
+   * option, it should only be used for values that the device does not automatically report.
+   * @param {Boolean} [userOpts.getOpts.getOnOnline] - Only for battery devices, get the value on
+   * device wake up. Avoid using this option, it should only be used for values that the device
+   * does not automatically report.
    * @param {Number|String} [userOpts.getOpts.pollInterval] - Interval (in ms) to poll with a
    * GET request. When provided a string, the device's setting with the string as ID will be
    * used (e.g. `poll_interval`).

--- a/lib/system/capabilities/locked/DOOR_LOCK.js
+++ b/lib/system/capabilities/locked/DOOR_LOCK.js
@@ -3,6 +3,7 @@
 module.exports = {
   get: 'DOOR_LOCK_OPERATION_GET',
   getOpts: {
+    // TODO: We should not assume that `getOnOnline` is necessary/safe for all devices
     getOnOnline: true,
   },
   set: 'DOOR_LOCK_OPERATION_SET',

--- a/lib/system/capabilities/measure_battery/BATTERY.js
+++ b/lib/system/capabilities/measure_battery/BATTERY.js
@@ -7,6 +7,7 @@
 module.exports = {
   get: 'BATTERY_GET',
   getOpts: {
+    // TODO: We should not assume that `getOnOnline` is necessary/safe for all devices
     getOnOnline: true,
   },
   report: 'BATTERY_REPORT',

--- a/lib/system/capabilities/measure_temperature/SENSOR_MULTILEVEL.js
+++ b/lib/system/capabilities/measure_temperature/SENSOR_MULTILEVEL.js
@@ -3,6 +3,7 @@
 module.exports = {
   get: 'SENSOR_MULTILEVEL_GET',
   getOpts: {
+    // TODO: We should not assume that `getOnOnline` is necessary/safe for all devices
     getOnOnline: true,
     getOnStart: true,
   },


### PR DESCRIPTION
Adds comments to the remaining `getOnOnline` options indicating that we should consider removing them in the future.

While the same is true for `getOnStart` I didn't add any comments to those.
As an additional note for `getOnStart`: when a device is paired it will reporting its initial values. Currently we init the device after pairing causing the app to not receive this initial state. `getOnStart` fixes this by re-requesting the values but we should probably buffer reports until the device (the homey app class) is initialised.

I also updated the JSDoc for `getOnStart` and `getOnOnline` to explain they should only be used when the values are not automatically reported by the device. In a future update we could rename `getOpts` to `pollingOpts` (or something similar) so it's clearer all these options are supposed to be used for devices that need to be polled for updates.



