### PR TITLE
NOTIFICATION_REPORT property Event (Parsed) is always false

### DIFF
--- a/lib/system/commandclasses/NOTIFICATION/index.js
+++ b/lib/system/commandclasses/NOTIFICATION/index.js
@@ -11,7 +11,7 @@ module.exports = payload => {
     const eventDefinition = notificationDefinition && notificationDefinition[eventCode];
 
     if (eventDefinition) {
-      const { name, push, pull } = events;
+      const { name, push, pull } = eventDefinition;
       payload['Event (Parsed)'] = name || push || pull || false;
       // Not sure why this exists, we use "Event (Parsed)" and they are the same
       payload['Event (Parsed 2)'] = payload['Event (Parsed)'];


### PR DESCRIPTION
I am upgrading my app (https://github.com/aartse/athom.zipato/tree/beta) to use SDK 3. But the motion sensor does not work after the upgrade. After debugging this is caused by the replaced package homey-zwavedriver. The reportParser callback for the command class NOTIFICATION_REPORT gets a report object where the property "Event (Parsed)" is always false.

this is caused by the wrong object being used to get the name of the event.