### PR TITLE
fixes system parser METER CC

### DIFF
--- a/lib/system/commandclasses/METER/defines.json
+++ b/lib/system/commandclasses/METER/defines.json
@@ -1,86 +1,46 @@
 {
+  "Supported Version": 6,
+  "Meter Type": {
+    "1": "Electric meter",
+    "2": "Gas meter",
+    "3": "Water meter",
+    "4": "Heating meter",
+    "5": "Cooling meter"
+  },
   "Rate Type": {
-    "0": "Reserved",
+    "0": "Unspecified",
     "1": "Import",
     "2": "Export",
-    "3": "Reserved"
+    "3": "Import and Export"
   },
   "Meter Scale": {
     "Electric meter": {
       "0": "kWh",
-      "1": "kVARh",
-      "2": "%",
+      "1": "kVAh",
+      "2": "W",
       "3": "Pulse count",
-      "4": "kVAR",
-      "5": "Voltage (V)",
-      "6": "Amperes (A)",
-      "7": "kW"
+      "4": "V",
+      "5": "A",
+      "6": "Powerfactor",
+      "7": "kVar",
+      "8": "kVarh"
     },
-    "Gas and water meter": {
+    "Gas meter": {
+      "0": "Cubic meter",
+      "1": "Cubic feet",
+      "3": "Pulse count"
+    },
+    "Water meter": {
       "0": "Cubic meter",
       "1": "Cubic feet",
       "2": "US gallon",
-      "3": "Pulse count",
-      "4": "IMP gallon",
-      "5": "Liter",
-      "6": "kPa",
-      "7": "Centum cubic feet",
-      "8": "Cubic meter per hour",
-      "9": "Liter per hour",
-      "10": "kWh",
-      "11": "MWh",
-      "12": "KW",
-      "13": "Hours"
+      "3": "Pulse count"
     },
-    "Heating and Cooling Meter": {
-      "0": "Cubic meter (m3)",
-      "1": "Metric Ton (tonne) (t)",
-      "2": "Cubic meter per hour (m3/h)",
-      "3": "Liter per hour (l/h)",
-      "4": "kW",
-      "5": "MW",
-      "6": "kWh",
-      "7": "MWh",
-      "8": "Giga Joule (GJ)",
-      "9": "Giga Calorie (Gcal)",
-      "10": "Celsius (Co)",
-      "11": "Fahrenheit (oF)",
-      "12": "Hours"
+    "Heating meter": {
+      "0": "kWh"
     },
-    "Electric Sub-Meter": {
-      "0": "kWh",
-      "1": "kVAh",
-      "2": "W",
-      "3": "Pulse Count",
-      "4": "V",
-      "5": "A",
-      "6": "Power Factor (%)"
+    "Cooling meter": {
+      "0": "kWh"
     }
-  },
-  "Meter Type": {
-    "1": "Single-E electric meter",
-    "2": "Gas meter",
-    "3": "Water meter",
-    "4": "Twin-E electric meter",
-    "5": "3P Single Direct electric meter",
-    "6": "3P Single ECT electric meter",
-    "7": "1 Phase Direct Electricity Meter",
-    "8": "Heating meter",
-    "9": "Cooling meter",
-    "10": "Combined Heating and Cooling Meter",
-    "11": "Electric Sub-Meter"
-  },
-  "Meter Type Scale Map": {
-    "1": "Electric meter",
-    "2": "Gas and water meter",
-    "3": "Gas and water meter",
-    "4": "Electric meter",
-    "5": "Electric meter",
-    "6": "Electric meter",
-    "7": "Electric meter",
-    "8": "Heating and Cooling Meter",
-    "9": "Heating and Cooling Meter",
-    "10": "Heating and Cooling Meter",
-    "11": "Electric Sub-Meter"
   }
 }

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -43,8 +43,7 @@ module.exports = payload => {
       scale: scaleValue,
       value: defines['Meter Scale'][meterTypeValue][scaleValue],
     };
-  }
-  else if (typeof scaleValue === 'undefined') {
+  } else if (typeof scaleValue === 'undefined') {
     // METER v3+
     const scaleValueBit2 = properties1['Scale bit 2']; // Scale Bit 2
     const scaleValueBit10 = properties2['Scale bits 10']; // Scale Bit 1 and 0
@@ -73,7 +72,7 @@ module.exports = payload => {
   const size = properties2['Size'];
   const precision = properties2['Precision'];
   const meterValue = payload['Meter Value'];
-  const previousMeterValue = payload['Previous Meter Value'];
+  let previousMeterValue = payload['Previous Meter Value'];
   const scale2 = payload['Scale 2 (Raw)'];
 
   // Append Meter Value (Parsed)
@@ -84,14 +83,17 @@ module.exports = payload => {
 
   // Append Previous Meter Value (Parsed) if it is there
   if (Buffer.isBuffer(previousMeterValue)) {
-    if (Buffer.byteLength(previousMeterValue) === size - 1 && scaleValue < 7 && Buffer.isBuffer(scale2)) {
+    if (
+      Buffer.byteLength(previousMeterValue) === size - 1
+      && scaleValue < 7
+      && Buffer.isBuffer(scale2)
+    ) {
       // If scale isn't 7, then re-add the first byte (Scale 2) back to "Previous Meter Value"
       previousMeterValue = Buffer.concat([previousMeterValue, scale2]);
-      payload['Previous Meter Value'] = previousMeterValue,
+      payload['Previous Meter Value'] = previousMeterValue;
       payload['Previous Meter Value (Parsed)'] = previousMeterValue.readIntBE(0, size);
       payload['Previous Meter Value (Parsed)'] /= 10 ** precision;
-    }
-    else if (Buffer.byteLength(previousMeterValue) === size) {
+    } else if (Buffer.byteLength(previousMeterValue) === size) {
       payload['Previous Meter Value (Parsed)'] = previousMeterValue.readIntBE(0, size);
       payload['Previous Meter Value (Parsed)'] /= 10 ** precision;
     }

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -7,52 +7,94 @@ module.exports = payload => {
   const properties1 = payload['Properties1'] || {};
   const properties2 = payload['Properties2'] || {};
 
-  // replace Meter Type
-  const meterTypeValue = properties1['Meter Type'];
-  if (meterTypeValue !== undefined) {
-    properties1['Meter Type (Parsed)'] = {
+  // Replace Meter Type (Parsed)
+  let meterTypeValue = payload['Meter Type'] || properties1['Meter Type'];
+
+  if (typeof meterTypeValue == 'number') {
+    meterTypeValue = defines['Meter Type'][meterTypeValue];
+  }
+  if (typeof meterType !== 'undefined') {
+    payload['Properties1']['Meter Type (Parsed)'] = {
       value: meterTypeValue,
-      name: defines['Meter Type'][meterTypeValue],
     };
   }
 
-  // replace Rate Type
-  const rateTypeValue = properties1['Rate Type'];
-  if (rateTypeValue !== undefined) {
-    properties1['Rate Type (Parsed)'] = {
+  // Replace Rate Type (Parsed)
+  let rateTypeValue = properties1['Rate Type'];
+
+  if (typeof rateTypeValue == 'number') {
+    rateTypeValue = defines['Rate Type'][rateTypeValue];
+  }
+  if (typeof rateTypeValue !== 'undefined') {
+    payload['Properties1']['Rate Type (Parsed)'] = {
       value: rateTypeValue,
-      name: defines['Rate Type'][rateTypeValue],
     };
   }
 
-  // replace Scale
-  const scaleValue = properties2['Scale'];
-  if (scaleValue !== undefined) {
-    const meterScaleType = defines['Meter Type Scale Map'][meterTypeValue];
-    const definitionScale = defines['Meter Scale'][meterScaleType];
+  // Append Scale (Parsed)
+  // METER v1 (properties1)
+  // METER v2+ (properties2)
+  let scaleValue = properties1['Scale'] || properties2['Scale'];
+  let scale2Value = null;
+  let scaleNameValue;
 
-    if (definitionScale) {
-      properties2['Scale (Parsed)'] = {
-        value: scaleValue,
-        name: definitionScale[scaleValue],
+  if (typeof scaleValue === 'number') {
+    payload['Scale (Parsed)'] = {
+      scale: scaleValue,
+      value: defines['Meter Scale'][meterTypeValue][scaleValue],
+    };
+  }
+  else if (typeof scaleValue === 'undefined') {
+    // METER v3+
+    const scaleValueBit2 = properties1['Scale bit 2']; // Scale Bit 2
+    const scaleValueBit10 = properties2['Scale bits 10']; // Scale Bit 1 and 0
+
+    if (typeof scaleValueBit2 !== 'undefined' && typeof scaleValueBit10 !== 'undefined') {
+      // Calculate the scale (Range: 0 - 7)
+      scaleValue = (scaleValueBit2) ? 4 : 0; // scale bit 2 (Range: 0, 4)
+      scaleValue += scaleValueBit10; // scale bit 1 and 0 (Range: 0 - 3)
+      scaleNameValue = scaleValue;
+
+      // "Scale 2" is only defined when "Scale" = 7
+      if (scaleValue === 7) {
+        scale2Value = payload['Scale 2'];
+        scaleNameValue += scale2Value;
+      }
+
+      payload['Scale (Parsed)'] = {
+        scale: scaleValue,
+        'scale 2': scale2Value,
+        value: defines['Meter Scale'][meterTypeValue][scaleNameValue],
       };
     }
   }
 
+  // Parse METER values
   const size = properties2['Size'];
   const precision = properties2['Precision'];
-
   const meterValue = payload['Meter Value'];
   const previousMeterValue = payload['Previous Meter Value'];
+  const scale2 = payload['Scale 2 (Raw)'];
 
+  // Append Meter Value (Parsed)
   if (Buffer.isBuffer(meterValue)) {
     payload['Meter Value (Parsed)'] = meterValue.readIntBE(0, size);
     payload['Meter Value (Parsed)'] /= 10 ** precision;
   }
 
+  // Append Previous Meter Value (Parsed) if it is there
   if (Buffer.isBuffer(previousMeterValue)) {
-    payload['Previous Meter Value (Parsed)'] = previousMeterValue.readIntBE(0, size);
-    payload['Previous Meter Value (Parsed)'] /= 10 ** precision;
+    if (Buffer.byteLength(previousMeterValue) === size - 1 && scaleValue < 7 && Buffer.isBuffer(scale2)) {
+      // If scale isn't 7, then re-add the first byte (Scale 2) back to "Previous Meter Value"
+      previousMeterValue = Buffer.concat([previousMeterValue, scale2]);
+      payload['Previous Meter Value'] = previousMeterValue,
+      payload['Previous Meter Value (Parsed)'] = previousMeterValue.readIntBE(0, size);
+      payload['Previous Meter Value (Parsed)'] /= 10 ** precision;
+    }
+    else if (Buffer.byteLength(previousMeterValue) === size) {
+      payload['Previous Meter Value (Parsed)'] = previousMeterValue.readIntBE(0, size);
+      payload['Previous Meter Value (Parsed)'] /= 10 ** precision;
+    }
   }
 
   return payload;

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -93,6 +93,10 @@ module.exports = payload => {
       payload['Previous Meter Value'] = previousMeterValue;
       payload['Previous Meter Value (Parsed)'] = previousMeterValue.readIntBE(0, size);
       payload['Previous Meter Value (Parsed)'] /= 10 ** precision;
+
+      // Reset "Scale 2" to 0
+      payload['Scale 2 (Raw)'] = Buffer.from([0]);
+      payload['Scale 2'] = 0;
     } else if (Buffer.byteLength(previousMeterValue) === size) {
       payload['Previous Meter Value (Parsed)'] = previousMeterValue.readIntBE(0, size);
       payload['Previous Meter Value (Parsed)'] /= 10 ** precision;

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -10,10 +10,10 @@ module.exports = payload => {
   // Replace Meter Type (Parsed)
   let meterTypeValue = payload['Meter Type'] || properties1['Meter Type'];
 
-  if (typeof meterTypeValue == 'number') {
+  if (typeof meterTypeValue === 'number') {
     meterTypeValue = defines['Meter Type'][meterTypeValue];
   }
-  if (typeof meterType !== 'undefined') {
+  if (typeof meterTypeValue !== 'undefined') {
     payload['Properties1']['Meter Type (Parsed)'] = {
       value: meterTypeValue,
     };
@@ -22,7 +22,7 @@ module.exports = payload => {
   // Replace Rate Type (Parsed)
   let rateTypeValue = properties1['Rate Type'];
 
-  if (typeof rateTypeValue == 'number') {
+  if (typeof rateTypeValue === 'number') {
     rateTypeValue = defines['Rate Type'][rateTypeValue];
   }
   if (typeof rateTypeValue !== 'undefined') {

--- a/lib/system/commandclasses/METER/report-compare
+++ b/lib/system/commandclasses/METER/report-compare
@@ -1,0 +1,119 @@
+// Version 3 old
+{
+  "Properties1 (Raw)": <Buffer 21>,
+  "Properties1": {
+    "Meter Type": 1,
+    "Rate Type": 1,
+    "Reserved": false,
+    "Meter Type (Parsed)": {
+      "value": "Electric Meter"
+    },
+    "Rate Type (Parsed)": {
+      "Import"
+    }
+  },
+  "Properties2 (Raw)": <Buffer 44>,
+  "Properties2": {
+    "Size": 4,
+    "Scale": 0,
+    "Precision": 2
+  },
+  "Meter Value": <Buffer 00 00 06 06>,
+  "Delta Time (Raw)": <Buffer 00 00>,
+  "Delta Time": 0,
+  "Meter Value (Parsed)": 15.42
+}
+
+// Version 3 new
+{
+  "Properties1 (Raw)": <Buffer 21>,
+  "Properties1": {
+    "Meter Type": 1,
+    "Rate Type": 1,
+    "Reserved": false,
+    "Meter Type (Parsed)": {
+      "value": "Electric Meter"
+    },
+    "Rate Type (Parsed)": {
+      "Import"
+    }
+  },
+  "Properties2 (Raw)": <Buffer 44>,
+  "Properties2": {
+    "Size": 4,
+    "Scale": 0,
+    "Precision": 2
+  },
+  "Meter Value": <Buffer 00 00 06 06>,
+  "Delta Time (Raw)": <Buffer 00 00>,
+  "Scale (Parsed)": {
+    "scale": 0,
+    "value": "kWh"
+  },
+  "Delta Time": 0,
+  "Meter Value (Parsed)": 15.42
+}
+
+// Version 4 old
+{
+  "Properties1 (Raw)": <Buffer 21>,
+  "Properties1": {
+    "Scale bit 2": false,
+    "Meter Type": "Electric meter",
+    "Rate Type": "Import",
+    "Meter Type (Parsed)": {
+      "value": "Electric meter"
+    },
+    "Rate Type (Parsed)": {
+      "value": "Import"
+    }
+  },
+  "Properties2 (Raw)": <Buffer 74>,
+  "Properties2": {
+    "Size": 4,
+    "Scale bits 10": 2,
+    "Precision": 3
+  },
+  "Meter Value": <Buffer 00 00 21 9e>,
+  "Delta Time (Raw)": <Buffer 00 22>,
+  "Delta Time": 34,
+  "Previous Meter Value": <Buffer 00 00 21>,
+  "Scale 2 (Raw)": <Buffer 95>,
+  "Scale 2": 149,
+  "Meter Value (Parsed)": 8.606
+}
+
+// Version 4 new
+{
+  "Properties1 (Raw)": <Buffer 21>,
+  "Properties1": {
+    "Scale bit 2": false,
+    "Meter Type": "Electric meter",
+    "Rate Type": "Import",
+    "Meter Type (Parsed)": {
+      "value": "Electric meter",
+    },
+    "Rate Type (Parsed)": {
+      "value": "Import"
+    }
+  },
+  "Properties2 (Raw)": <Buffer 74>,
+  "Properties2": {
+    "Size": 4,
+    "Scale bits 10": 2,
+    "Precision": 3
+  },
+  "Meter Value": <Buffer 00 00 21 9e>,
+  "Delta Time (Raw)": <Buffer 00 22>,
+  "Delta Time": 34,
+  "Previous Meter Value": <Buffer 00 00 21 95>,
+  "Scale 2 (Raw)": <Buffer 95>,
+  "Scale 2": 149,
+  "Scale (Parsed)": {
+    "scale": 2,
+    "scale 2": null,
+    "name": "W"
+  },
+  "Meter Value (Parsed)": 8.606,
+  "Previous Meter Value (Parsed)": 8.597
+}


### PR DESCRIPTION
Fixed:
- All (parsed) values were never pushed into the payload object

- METER v1: the Meter Type is still outside the Properties1 object, where the Scale (etc) is in Properties1, this is now taken into account in the system parser.

- Scale consists of 3 bits from v3 and up, Scale bit 2 (1 bit) and Scale bits 10 (2 bits),
this is now accounted for in the system parser and fixed in "Scale (Parsed)".

- Z-Wave Core expects "Scale 2" to **always** exist in METER v4 and up, setting the last byte of the Previous Meter Value to "Scale 2".
But this is only the case if "Scale" is 7, and _must be omitted_ if it isn't, making the previous meter value a byte too short giving an error.
Now it will check if the "Scale" is under 7, and if it is concat back "Scale 2" to "Previous Meter Value"
Z-Wave documentation:

> Scale 2 (8 bits)
> This field is used to advertise the unit used for the Meter Value and Previous Meter Value fields.
> This field MUST be present in the command if the Scale field is set to 7 (M.S.T).
> This field MUST be omitted if the Scale field is set to a different value than 7.
> This field MUST be encoded according to Table 73.

- Defines.json was the wrong list, it was "METER TABLE MONITOR" (SDS14305), instead of the "normal" METER table.
I think the current **core** parser also uses this list(?)
In theorie most developers would not have seen this, as the wrong value(s) was never pushed into the payload object, and the debug report has the parsed values as ["object"] instead of the values.
Have checked all apps and system capabilities that could have such a METER device, but none used the parsed values, so changing it back to the _normal_ list won't break anything.

Added:
- Scale (Parsed), now it is visible as to what type of Meter value is send, and has additional (fixed) Scale and Scale 2 (METER v4+) values.
Did decide to put it in the main payload (not in Properties1 or 2 object), for 2 reasons:
1 "Scale" differs in position per METER version,
2 "Scale 2" is also outside of the properties objects

Conclusion:
None of the existing report is altered in any breaking way, keeping it fully backwards compatible.
It just fixes the (never used) "Previous Meter Value" error, the wrong METER list, and appends "Scale (Parsed)".