### PR TITLE
fix: cc meter parsing

### DIFF
--- a/lib/system/commandclasses/METER/defines.json
+++ b/lib/system/commandclasses/METER/defines.json
@@ -1,86 +1,46 @@
 {
+  "Supported Version": 6,
+  "Meter Type": {
+    "1": "Electric meter",
+    "2": "Gas meter",
+    "3": "Water meter",
+    "4": "Heating meter",
+    "5": "Cooling meter"
+  },
   "Rate Type": {
-    "0": "Reserved",
+    "0": "Unspecified",
     "1": "Import",
     "2": "Export",
-    "3": "Reserved"
+    "3": "Import and Export"
   },
   "Meter Scale": {
     "Electric meter": {
       "0": "kWh",
-      "1": "kVARh",
-      "2": "%",
+      "1": "kVAh",
+      "2": "W",
       "3": "Pulse count",
-      "4": "kVAR",
-      "5": "Voltage (V)",
-      "6": "Amperes (A)",
-      "7": "kW"
+      "4": "V",
+      "5": "A",
+      "6": "Powerfactor",
+      "7": "kVar",
+      "8": "kVarh"
     },
-    "Gas and water meter": {
+    "Gas meter": {
+      "0": "Cubic meter",
+      "1": "Cubic feet",
+      "3": "Pulse count"
+    },
+    "Water meter": {
       "0": "Cubic meter",
       "1": "Cubic feet",
       "2": "US gallon",
-      "3": "Pulse count",
-      "4": "IMP gallon",
-      "5": "Liter",
-      "6": "kPa",
-      "7": "Centum cubic feet",
-      "8": "Cubic meter per hour",
-      "9": "Liter per hour",
-      "10": "kWh",
-      "11": "MWh",
-      "12": "KW",
-      "13": "Hours"
+      "3": "Pulse count"
     },
-    "Heating and Cooling Meter": {
-      "0": "Cubic meter (m3)",
-      "1": "Metric Ton (tonne) (t)",
-      "2": "Cubic meter per hour (m3/h)",
-      "3": "Liter per hour (l/h)",
-      "4": "kW",
-      "5": "MW",
-      "6": "kWh",
-      "7": "MWh",
-      "8": "Giga Joule (GJ)",
-      "9": "Giga Calorie (Gcal)",
-      "10": "Celsius (Co)",
-      "11": "Fahrenheit (oF)",
-      "12": "Hours"
+    "Heating meter": {
+      "0": "kWh"
     },
-    "Electric Sub-Meter": {
-      "0": "kWh",
-      "1": "kVAh",
-      "2": "W",
-      "3": "Pulse Count",
-      "4": "V",
-      "5": "A",
-      "6": "Power Factor (%)"
+    "Cooling meter": {
+      "0": "kWh"
     }
-  },
-  "Meter Type": {
-    "1": "Single-E electric meter",
-    "2": "Gas meter",
-    "3": "Water meter",
-    "4": "Twin-E electric meter",
-    "5": "3P Single Direct electric meter",
-    "6": "3P Single ECT electric meter",
-    "7": "1 Phase Direct Electricity Meter",
-    "8": "Heating meter",
-    "9": "Cooling meter",
-    "10": "Combined Heating and Cooling Meter",
-    "11": "Electric Sub-Meter"
-  },
-  "Meter Type Scale Map": {
-    "1": "Electric meter",
-    "2": "Gas and water meter",
-    "3": "Gas and water meter",
-    "4": "Electric meter",
-    "5": "Electric meter",
-    "6": "Electric meter",
-    "7": "Electric meter",
-    "8": "Heating and Cooling Meter",
-    "9": "Heating and Cooling Meter",
-    "10": "Heating and Cooling Meter",
-    "11": "Electric Sub-Meter"
   }
 }

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -74,6 +74,19 @@ module.exports = payload => {
         value: scale2ValueCorrected,
         name: meterTypeScaleDefinition[scale2ValueCorrected],
       };
+    } else if (Buffer.isBuffer(payload['Previous Meter Value'])) {
+      // The parser split these up because it reserved space for "Scale 2".
+      // Since "Scale" is not 7 we correct the payload.
+
+      // Append "Scale 2" to "Previous Meter Value"
+      payload['Previous Meter Value'] = Buffer.concat([
+        payload['Previous Meter Value'],
+        payload['Scale 2 (Raw)'],
+      ]);
+
+      // Remove "Scale 2" from payload
+      delete payload['Scale 2 (Raw)'];
+      delete payload['Scale 2'];
     }
   }
 

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -68,11 +68,12 @@ module.exports = payload => {
   if (scale2Value !== undefined) {
     // "Scale 2" is present when "Scale" is 7 (0b111)
     if (scaleValueBit2 === 0b1 && scaleValueBit10 === 0b11) {
-      const scale2ValueCorrected = (scale2Value << 3) | 0b111;
+      // This value is internal, we just continue numbering scales
+      const scale2ValueLookup = (scale2Value << 3) | 0b111;
 
-      payload['Scale (Parsed)'] = {
-        value: scale2ValueCorrected,
-        name: meterTypeScaleDefinition[scale2ValueCorrected],
+      payload['Scale 2 (Parsed)'] = {
+        value: scale2Value,
+        name: meterTypeScaleDefinition[scale2ValueLookup],
       };
     } else if (Buffer.isBuffer(payload['Previous Meter Value'])) {
       // The parser split these up because it reserved space for "Scale 2".

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -46,6 +46,22 @@ module.exports = payload => {
     };
   }
 
+  // METER v3+
+  const scaleValueBit2 = properties1['Scale bit 2']; // Scale Bit 2
+  const scaleValueBit10 = properties2['Scale bits 10']; // Scale Bit 1 and 0
+
+  if (scaleValueBit2 !== undefined && scaleValueBit10 !== undefined) {
+    // Combine the Scale bits
+    // Scale (2) the most significant bit of Scale
+    // Scale (1:0) 2 least significant bits of Scale
+    const scaleValueCorrected = (scaleValueBit2 << 2) | scaleValueBit10;
+
+    payload['Scale (Parsed)'] = {
+      value: scaleValueCorrected,
+      name: meterTypeScaleDefinition[scaleValueCorrected],
+    };
+  }
+
   const size = properties2['Size'];
   const precision = properties2['Precision'];
 

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -38,7 +38,7 @@ module.exports = payload => {
   const scaleName = meterTypeScaleDefinition[scaleValue];
 
   if (scaleValue !== undefined) {
-    payload['Properties2']['Scale (Parsed)'] = {
+    payload['Scale (Parsed)'] = {
       value: scaleValue,
       name: scaleName,
     };

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -74,7 +74,8 @@ module.exports = payload => {
   }
 
   // Add Previous Meter Value (Parsed)
-  if (Buffer.isBuffer(previousMeterValue)) {
+  // Due to an internal bug the size of "Previous Meter Value" is not correctly enforced
+  if (Buffer.isBuffer(previousMeterValue) && previousMeterValue.length === size) {
     payload['Previous Meter Value (Parsed)'] = previousMeterValue.readIntBE(0, size);
     payload['Previous Meter Value (Parsed)'] /= 10 ** precision;
   }

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -3,36 +3,35 @@
 const defines = require('./defines.json');
 
 module.exports = payload => {
-  // replace Meter Type
   const properties1 = payload['Properties1'] || {};
   const properties2 = payload['Properties2'] || {};
 
-  // replace Meter Type
+  // Add Meter Type (Parsed)
   const meterTypeValue = properties1['Meter Type'];
   if (meterTypeValue !== undefined) {
-    properties1['Meter Type (Parsed)'] = {
+    payload['Properties1']['Meter Type (Parsed)'] = {
       value: meterTypeValue,
       name: defines['Meter Type'][meterTypeValue],
     };
   }
 
-  // replace Rate Type
+  // Add Rate Type (Parsed)
   const rateTypeValue = properties1['Rate Type'];
   if (rateTypeValue !== undefined) {
-    properties1['Rate Type (Parsed)'] = {
+    payload['Properties1']['Rate Type (Parsed)'] = {
       value: rateTypeValue,
       name: defines['Rate Type'][rateTypeValue],
     };
   }
 
-  // replace Scale
+  // Add Scale (Parsed)
   const scaleValue = properties2['Scale'];
   if (scaleValue !== undefined) {
     const meterScaleType = defines['Meter Type Scale Map'][meterTypeValue];
     const definitionScale = defines['Meter Scale'][meterScaleType];
 
     if (definitionScale) {
-      properties2['Scale (Parsed)'] = {
+      payload['Properties2']['Scale (Parsed)'] = {
         value: scaleValue,
         name: definitionScale[scaleValue],
       };
@@ -45,11 +44,13 @@ module.exports = payload => {
   const meterValue = payload['Meter Value'];
   const previousMeterValue = payload['Previous Meter Value'];
 
+  // Add Meter Value (Parsed)
   if (Buffer.isBuffer(meterValue)) {
     payload['Meter Value (Parsed)'] = meterValue.readIntBE(0, size);
     payload['Meter Value (Parsed)'] /= 10 ** precision;
   }
 
+  // Add Previous Meter Value (Parsed)
   if (Buffer.isBuffer(previousMeterValue)) {
     payload['Previous Meter Value (Parsed)'] = previousMeterValue.readIntBE(0, size);
     payload['Previous Meter Value (Parsed)'] /= 10 ** precision;

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -2,40 +2,46 @@
 
 const defines = require('./defines.json');
 
+const METER_TYPE_DEFINITION = defines['Meter Type'];
+const METER_SCALE_DEFINITION = defines['Meter Scale'];
+const RATE_TYPE_DEFINITION = defines['Rate Type'];
+
 module.exports = payload => {
   const properties1 = payload['Properties1'] || {};
   const properties2 = payload['Properties2'] || {};
 
   // Add Meter Type (Parsed)
-  const meterTypeValue = properties1['Meter Type'];
+  const meterTypeValue = payload['Meter Type'] || properties1['Meter Type'];
+  const meterTypeName = METER_TYPE_DEFINITION[meterTypeValue];
+
   if (meterTypeValue !== undefined) {
     payload['Properties1']['Meter Type (Parsed)'] = {
       value: meterTypeValue,
-      name: defines['Meter Type'][meterTypeValue],
+      name: meterTypeName,
     };
   }
 
   // Add Rate Type (Parsed)
   const rateTypeValue = properties1['Rate Type'];
+  const rateTypeName = RATE_TYPE_DEFINITION[rateTypeValue];
+
   if (rateTypeValue !== undefined) {
     payload['Properties1']['Rate Type (Parsed)'] = {
       value: rateTypeValue,
-      name: defines['Rate Type'][rateTypeValue],
+      name: rateTypeName,
     };
   }
 
   // Add Scale (Parsed)
+  const meterTypeScaleDefinition = METER_SCALE_DEFINITION[meterTypeName] || {};
   const scaleValue = properties2['Scale'];
-  if (scaleValue !== undefined) {
-    const meterScaleType = defines['Meter Type Scale Map'][meterTypeValue];
-    const definitionScale = defines['Meter Scale'][meterScaleType];
+  const scaleName = meterTypeScaleDefinition[scaleValue];
 
-    if (definitionScale) {
-      payload['Properties2']['Scale (Parsed)'] = {
-        value: scaleValue,
-        name: definitionScale[scaleValue],
-      };
-    }
+  if (scaleValue !== undefined) {
+    payload['Properties2']['Scale (Parsed)'] = {
+      value: scaleValue,
+      name: scaleName,
+    };
   }
 
   const size = properties2['Size'];

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -34,13 +34,15 @@ module.exports = payload => {
 
   // Add Scale (Parsed)
   const meterTypeScaleDefinition = METER_SCALE_DEFINITION[meterTypeName] || {};
-  const scaleValue = properties2['Scale'];
-  const scaleName = meterTypeScaleDefinition[scaleValue];
+
+  // METER v1 (properties1)
+  // METER v2 (properties2)
+  const scaleValue = properties1['Scale'] || properties2['Scale'];
 
   if (scaleValue !== undefined) {
     payload['Scale (Parsed)'] = {
       value: scaleValue,
-      name: scaleName,
+      name: meterTypeScaleDefinition[scaleValue],
     };
   }
 

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -2,32 +2,25 @@
 
 const defines = require('./defines.json');
 
-const METER_TYPE_DEFINITION = defines['Meter Type'];
-const RATE_TYPE_DEFINITION = defines['Rate Type'];
-
 module.exports = payload => {
   const properties1 = payload['Properties1'] || {};
   const properties2 = payload['Properties2'] || {};
 
   // Add Meter Type (Parsed)
   const meterTypeValue = payload['Meter Type'] || properties1['Meter Type'];
-  const meterTypeName = METER_TYPE_DEFINITION[meterTypeValue];
-
   if (meterTypeValue !== undefined) {
     payload['Properties1']['Meter Type (Parsed)'] = {
       value: meterTypeValue,
-      name: meterTypeName,
+      name: defines['Meter Type'][meterTypeValue],
     };
   }
 
   // Add Rate Type (Parsed)
   const rateTypeValue = properties1['Rate Type'];
-  const rateTypeName = RATE_TYPE_DEFINITION[rateTypeValue];
-
   if (rateTypeValue !== undefined) {
     payload['Properties1']['Rate Type (Parsed)'] = {
       value: rateTypeValue,
-      name: rateTypeName,
+      name: defines['Rate Type'][rateTypeValue],
     };
   }
 

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -62,6 +62,21 @@ module.exports = payload => {
     };
   }
 
+  // METER v4+
+  const scale2Value = payload['Scale 2'];
+
+  if (scale2Value !== undefined) {
+    // "Scale 2" is present when "Scale" is 7 (0b111)
+    if (scaleValueBit2 === 0b1 && scaleValueBit10 === 0b11) {
+      const scale2ValueCorrected = (scale2Value << 3) | 0b111;
+
+      payload['Scale (Parsed)'] = {
+        value: scale2ValueCorrected,
+        name: meterTypeScaleDefinition[scale2ValueCorrected],
+      };
+    }
+  }
+
   const size = properties2['Size'];
   const precision = properties2['Precision'];
 

--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -3,7 +3,6 @@
 const defines = require('./defines.json');
 
 const METER_TYPE_DEFINITION = defines['Meter Type'];
-const METER_SCALE_DEFINITION = defines['Meter Scale'];
 const RATE_TYPE_DEFINITION = defines['Rate Type'];
 
 module.exports = payload => {
@@ -32,50 +31,21 @@ module.exports = payload => {
     };
   }
 
-  // Add Scale (Parsed)
-  const meterTypeScaleDefinition = METER_SCALE_DEFINITION[meterTypeName] || {};
+  // Correct Previous Meter Value
+  if (
+    Buffer.isBuffer(payload['Scale 2 (Raw)'])
+    && Buffer.isBuffer(payload['Previous Meter Value'])
+  ) {
+    const scaleValueBit2 = properties1['Scale bit 2']; // Scale Bit 2
+    const scaleValueBit10 = properties2['Scale bits 10']; // Scale Bit 1 and 0
 
-  // METER v1 (properties1)
-  // METER v2 (properties2)
-  const scaleValue = properties1['Scale'] || properties2['Scale'];
-
-  if (scaleValue !== undefined) {
-    payload['Scale (Parsed)'] = {
-      value: scaleValue,
-      name: meterTypeScaleDefinition[scaleValue],
-    };
-  }
-
-  // METER v3+
-  const scaleValueBit2 = properties1['Scale bit 2']; // Scale Bit 2
-  const scaleValueBit10 = properties2['Scale bits 10']; // Scale Bit 1 and 0
-
-  if (scaleValueBit2 !== undefined && scaleValueBit10 !== undefined) {
-    // Combine the Scale bits
+    // Combine the Scale bits (Meter v3+)
     // Scale (2) the most significant bit of Scale
     // Scale (1:0) 2 least significant bits of Scale
     const scaleValueCorrected = (scaleValueBit2 << 2) | scaleValueBit10;
 
-    payload['Scale (Parsed)'] = {
-      value: scaleValueCorrected,
-      name: meterTypeScaleDefinition[scaleValueCorrected],
-    };
-  }
-
-  // METER v4+
-  const scale2Value = payload['Scale 2'];
-
-  if (scale2Value !== undefined) {
-    // "Scale 2" is present when "Scale" is 7 (0b111)
-    if (scaleValueBit2 === 0b1 && scaleValueBit10 === 0b11) {
-      // This value is internal, we just continue numbering scales
-      const scale2ValueLookup = (scale2Value << 3) | 0b111;
-
-      payload['Scale 2 (Parsed)'] = {
-        value: scale2Value,
-        name: meterTypeScaleDefinition[scale2ValueLookup],
-      };
-    } else if (Buffer.isBuffer(payload['Previous Meter Value'])) {
+    // "Scale 2" is only present when "Scale" is 7 (0b111)
+    if (scaleValueCorrected !== 7) {
       // The parser split these up because it reserved space for "Scale 2".
       // Since "Scale" is not 7 we correct the payload.
 


### PR DESCRIPTION
This PR supersedes https://github.com/athombv/node-homey-zwavedriver/pull/73

It implements all the fixes from that PR but ensures the logic for parsing a specified cc version is easily separated out.
This is done so it would be easier to, in the future, do command parsing based on command class version.
Additionally this splits the various fixes into different commits to make it easier to review the individual changes.

- 0a1afa3 Corrects the `defines.json`. This was the wrong list, it was "METER TABLE MONITOR" (SDS14305), instead of the "normal" METER table.
- 98e632b Moves the parsed scale value to `payload` instead of in `Properties 2`.
- 153995b adds support for METER v1, in this version the `Scale` is part of `payload` and not `Properties 1`.
- fe679c8 corrects handling of METER v3+, by correctly computing the `Scale` value from `Scale bit 2` and `Scale bits 10`.
- 82e7867 corrects handling of METER v4+, add `Scale 2` to `Scale` if the "regular" `Scale` is set to `7`.
- c2b3c5e fixes a bug with regards to `Previous Meter Value`. Our parser reserves a byte for `Scale 2` but if `Scale` is not set to `7` that byte is actually the last byte of `Previous Meter Value`.

This was all figured out by @caseda in #73 so massive thanks!

Note that the biggest difference between this PR and #73 is that here `(Parsed)` properties are consistently `{ value: number, name: string | undefined }`.