### PR TITLE
chore: cleanup jsdoc comments

### DIFF
--- a/lib/ZwaveDevice.js
+++ b/lib/ZwaveDevice.js
@@ -23,8 +23,11 @@ const commandClassParsers = {
 // TODO measure_pressure capability parser
 
 /**
- * @classdesc {@link https://apps.developer.homey.app/the-basics/devices/settings Device settings}
- * used by system capabilities:
+ * @classdesc
+ * Extends {@link https://apps-sdk-v3.developer.homey.app/Device.html Homey.Device}
+ *
+ * {@link https://apps.developer.homey.app/the-basics/devices/settings Device settings} used by
+ * system capabilities:
  * - `invertWindowCoveringsDirection` type `checkbox`, Used by several windowcoverings capabilities,
  *    if true it will invert the up/down direction
  * - `invertWindowCoveringsTiltDirection` type `checkbox`, Used by several windowcoverings

--- a/lib/ZwaveDevice.js
+++ b/lib/ZwaveDevice.js
@@ -23,17 +23,21 @@ const commandClassParsers = {
 // TODO measure_pressure capability parser
 
 /**
- * @extends Homey.Device
- * @desc {@link https://developer.athom.com/docs/apps/Device.html#getSetting Device settings}
+ * @classdesc {@link https://apps.developer.homey.app/the-basics/devices/settings Device settings}
  * used by system capabilities:
- * - `invertWindowCoveringsDirection {boolean}` - Used by several windowcoverings capabilities,
+ * - `invertWindowCoveringsDirection` type `checkbox`, Used by several windowcoverings capabilities,
  *    if true it will invert the up/down direction
- * - `invertWindowCoveringsTiltDirection {boolean}` - Used by several windowcoverings
+ * - `invertWindowCoveringsTiltDirection` type `checkbox`, Used by several windowcoverings
  *    capabilities, if true it will invert the tilt direction
- * @property {string} thermostatSetpointType - The 'Setpoint Type' used in the
- * THERMOSTAT_SETPOINT commandclass for the target_temperature capability
+ * @hideconstructor
  */
 class ZwaveDevice extends Homey.Device {
+
+  /**
+   * The 'Setpoint Type' used for the target_temperature capability.
+   * @type {string}
+   */
+  thermostatSetpointType = 'Heating 1';
 
   /**
    * This method can be overridden. It will be called when the {@link ZwaveDevice} instance is
@@ -56,7 +60,7 @@ class ZwaveDevice extends Homey.Device {
   onNodeInit({ node }) {}
 
   /**
-   * @deprecated since v1.0.0 - Legacy from homey-meshdriver, use {@link onNodeInit} instead.
+   * deprecated since v1.0.0 - Legacy from homey-meshdriver, use {@link onNodeInit} instead.
    * This method can be overridden. It will be called when the {@link ZwaveDevice} instance is
    * ready and did initialize a {@link Homey.ZwaveNode}.
    * @abstract
@@ -158,7 +162,7 @@ class ZwaveDevice extends Homey.Device {
    * @param oldSettings
    * @param newSettings
    * @param changedKeysArr
-   * @returns {Promise}
+   * @returns {Promise<string>}
    */
   async onSettings({ oldSettings, newSettings, changedKeys = [] }) {
     let changeSettingError = '';
@@ -265,13 +269,13 @@ class ZwaveDevice extends Homey.Device {
   /**
    * Parses a given setting uses the registered setting parser or the system parser and returns
    * the parsed value.
-   * @param {Object} settingObj
+   * @param {object} settingObj
    * @param {string} [settingObj.id] - Optional setting id (key) if provided in manifest
    * @param settingObj.index - Parameter index
    * @param settingObj.size - Parameter size
    * @param settingObj.signed - Parameter signed or not
    * @param value - Input value to parse
-   * @returns {ArrayBuffer|Error}
+   * @returns {Buffer|Error}
    * @private
    */
   _parseSetting(settingObj = {}, value) {
@@ -457,8 +461,8 @@ class ZwaveDevice extends Homey.Device {
    * @param {string} capabilityId
    * @param {string} commandClassId
    * @param {boolean|number|string} value - the capability value to set (e.g 0 - 1 for dim)
-   * @param {Object} opts - capability options object
-   * @returns {Promise<string|*>}
+   * @param {object} opts - capability options object
+   * @returns {Promise<any>}
    * @private
    */
   async _setCapabilityValue(capabilityId, commandClassId, value, opts = {}) {
@@ -682,7 +686,7 @@ class ZwaveDevice extends Homey.Device {
    * if possible. Else it will return null.
    * @param {string} capabilityId
    * @param {string} commandClassId
-   * @returns {Object|null}
+   * @returns {object|null}
    * @private
    */
   _getDeviceClassSpecificSystemCapability(capabilityId, commandClassId) {
@@ -705,43 +709,43 @@ class ZwaveDevice extends Homey.Device {
    * will make sure that the highest matching version will be used, falling back to `getParser`.
    * @param {string} capabilityId - The Homey capability id (e.g. `onoff`)
    * @param {string} commandClassId - The command class id (e.g. `BASIC`)
-   * @param {Object} [userOpts] - The object with options for this capability/commandclass
+   * @param {object} [userOpts] - The object with options for this capability/commandclass
    * combination. These will extend system options, if available (`/system/`).
-   * @param {String} [userOpts.get] - The command to get a value (e.g. `BASIC_GET`)
-   * @param {String} [userOpts.getParser] - The function that is called when a GET request is
+   * @param {string} [userOpts.get] - The command to get a value (e.g. `BASIC_GET`)
+   * @param {string} [userOpts.getParser] - The function that is called when a GET request is
    * made. Should return an Object.
-   * @param {Object} [userOpts.getOpts
-   * @param {Boolean} [userOpts.getOpts.getOnStart] - Get the value on App start. Avoid using this
+   * @param {object} [userOpts.getOpts
+   * @param {boolean} [userOpts.getOpts.getOnStart] - Get the value on App start. Avoid using this
    * option, it should only be used for values that the device does not automatically report.
-   * @param {Boolean} [userOpts.getOpts.getOnOnline] - Only for battery devices, get the value on
+   * @param {boolean} [userOpts.getOpts.getOnOnline] - Only for battery devices, get the value on
    * device wake up. Avoid using this option, it should only be used for values that the device
    * does not automatically report.
-   * @param {Number|String} [userOpts.getOpts.pollInterval] - Interval (in ms) to poll with a
+   * @param {number|string} [userOpts.getOpts.pollInterval] - Interval (in ms) to poll with a
    * GET request. When provided a string, the device's setting with the string as ID will be
    * used (e.g. `poll_interval`).
-   * @param {Number} [userOpts.getOpts.pollMultiplication] - Multiplication factor for the
+   * @param {number} [userOpts.getOpts.pollMultiplication] - Multiplication factor for the
    * pollInterval key, must be a number. (e.g. 1000 to convert to seconds, 60.000 for minutes,
    * 3600000 for hours).
-   * @param {String} [userOpts.set] - The command to set a value (e.g. `BASIC_SET`)
+   * @param {string} [userOpts.set] - The command to set a value (e.g. `BASIC_SET`)
    * @param {Function} [userOpts.setParser] - The function that is called when a SET request is
    * made. Should return an Object.
    * @param {number|boolean|string} [userOpts.setParser.value] - The value of the Homey capability
-   * @param {Object} [userOpts.setParser.opts] - Options for the capability command
+   * @param {any} [userOpts.setParser.opts] - Options for the capability command
    * @param {Function} [userOpts.fn] - This function is called after a setCapabilityValue has
    * been called.
-   * @param {Object} [userOpts.fn.value] - The capability value
-   * @param {Object} [userOpts.fn.opts] - The capability opts
-   * @param {String} [userOpts.report] - The command to report a value (e.g. `BASIC_REPORT`)
-   * @param {Boolean} [userOpts.reportParserOverride] - Boolean flag to determine if the
+   * @param {any} [userOpts.fn.value] - The capability value
+   * @param {any} [userOpts.fn.opts] - The capability opts
+   * @param {string} [userOpts.report] - The command to report a value (e.g. `BASIC_REPORT`)
+   * @param {boolean} [userOpts.reportParserOverride] - Boolean flag to determine if the
    * `reportParser` method should override all report parsers. (Assumed false when not specified).
    * @param {Function} [userOpts.reportParser] - The function that is called when a REPORT
    * request is made. Should return an Object.
-   * @param {Object} [userOpts.reportParser.report] - The report object
-   * @param {Number} [userOpts.multiChannelNodeId] - An ID to use a MultiChannel Node for this
+   * @param {any} [userOpts.reportParser.report] - The report object
+   * @param {number} [userOpts.multiChannelNodeId] - An ID to use a MultiChannel Node for this
    * capability.
    * @param {Function} [userOpts.fn] - This function is called after a setCapabilityValue has
    * been executed.
-   * @param {Object} [userOpts.fn.value] - The capability value
+   * @param {any} [userOpts.fn.value] - The capability value
    */
   registerCapability(capabilityId, commandClassId, userOpts) {
     // Check if device has the command class we're trying to register, if not, abort
@@ -839,7 +843,7 @@ class ZwaveDevice extends Homey.Device {
    * @param {string} commandClassId - The ID of the Command Class (e.g. `BASIC`)
    * @param {string} commandId - The ID of the Command (e.g. `BASIC_REPORT`)
    * @param {Function} triggerFn
-   * @param {Object} triggerFn.report - The received report
+   * @param {any} triggerFn.report - The received report
    */
   registerReportListener(commandClassId, commandId, triggerFn) {
     const commandClass = this.node.CommandClass[`COMMAND_CLASS_${commandClassId}`];
@@ -914,7 +918,7 @@ class ZwaveDevice extends Homey.Device {
    * @param {string} commandClassId - The ID of the Command Class (e.g. `BASIC`)
    * @param {string} commandId - The ID of the Command (e.g. `BASIC_REPORT`)
    * @param {Function} triggerFn
-   * @param {Object} triggerFn.report - The received report
+   * @param {any} triggerFn.report - The received report
    */
   registerMultiChannelReportListener(multiChannelNodeId, commandClassId, commandId, triggerFn) {
     // Check for valid multi channel nodes
@@ -952,7 +956,7 @@ class ZwaveDevice extends Homey.Device {
   /**
    * Method that will check if the node has the provided command class
    * @param {string} commandClassId - For example: SWITCH_BINARY
-   * @param {Object} opts
+   * @param {object} opts
    * @param {number} opts.multiChannelNodeId - Multi channel node id to check for command class
    * @returns {boolean}
    */
@@ -975,11 +979,11 @@ class ZwaveDevice extends Homey.Device {
   /**
    * Method that gets a CommandClass object by commandClassId. Optionally, it can get the object
    * on a multichannel node if the multiChannelNodeId is provided.
-   * @param {String} commandClassId
-   * @param {Object} opts
-   * @param {Number} opts.multiChannelNodeId - Provide this id if the command class should be
+   * @param {string} commandClassId
+   * @param {object} opts
+   * @param {number} opts.multiChannelNodeId - Provide this id if the command class should be
    * located on a mc node.
-   * @returns {Error|boolean|*}
+   * @returns {Error|boolean|any}
    */
   getCommandClass(commandClassId, opts = {}) {
     if (Object.prototype.hasOwnProperty.call(opts, 'multiChannelNodeId')) {
@@ -1003,8 +1007,8 @@ class ZwaveDevice extends Homey.Device {
 
   /**
    * Method that gets all multi channel node ids that have a specific deviceClassGeneric.
-   * @param {String} deviceClassGeneric
-   * @returns {Array}
+   * @param {string} deviceClassGeneric
+   * @returns {number[]}
    */
   getMultiChannelNodeIdsByDeviceClassGeneric(deviceClassGeneric) {
     if (!Object.prototype.hasOwnProperty.call(this.node, 'MultiChannelNodes')) return [];
@@ -1023,8 +1027,8 @@ class ZwaveDevice extends Homey.Device {
    * @param {string} capabilityId
    * @param {string} commandClassId
    * @param {number|boolean|string} value - the capability value to set (e.g 0 - 1 for dim)
-   * @param {Object} opts - capability options object
-   * @returns {Promise<string|*>}
+   * @param {object} opts - capability options object
+   * @returns {Promise<any>}
    */
   async executeCapabilitySetCommand(capabilityId, commandClassId, value, opts = {}) {
     return this._setCapabilityValue(capabilityId, commandClassId, value, opts);
@@ -1035,7 +1039,7 @@ class ZwaveDevice extends Homey.Device {
    * node of the device and then looks for the COMMAND_CLASS_METER.
    * @param multiChannelNodeId - define the multi channel node id in case the
    * COMMAND_CLASS_METER is on a multi channel node.
-   * @returns {Promise<unknown>}
+   * @returns {Promise<any>}
    */
   async meterReset({ multiChannelNodeId } = {}) {
     // Get command class object (on mc node if needed)
@@ -1058,14 +1062,14 @@ class ZwaveDevice extends Homey.Device {
    * default options.useSettingParser is true, then the value will first be parsed by the
    * registered setting parser or the system parser before sending. It will only be able to use
    * the registered setting parser if options.id is provided.
-   * @param options
-   * @param options.index
-   * @param options.size
-   * @param options.id
-   * @param [options.signed]
-   * @param [options.useSettingParser=true]
-   * @param value
-   * @returns {Promise.<*>}
+   * @param {object} options
+   * @param {number} options.index
+   * @param {number} options.size
+   * @param {number} options.id
+   * @param {boolean} [options.signed]
+   * @param {boolean} [options.useSettingParser=true]
+   * @param {any} value
+   * @returns {Promise<any>}
    */
   async configurationSet(options = {}, value) {
     if (!options.hasOwnProperty('index') && !options.hasOwnProperty('id')) {
@@ -1160,9 +1164,9 @@ class ZwaveDevice extends Homey.Device {
 
   /**
    * Method that retrieves the value of a configuration parameter from the node.
-   * @param {Object} options
+   * @param {object} options
    * @param {number} options.index - Parameter index
-   * @returns {*}
+   * @returns {any}
    */
   async configurationGet(options = {}) {
     if (!options.hasOwnProperty('index')) return Promise.reject(new Error('missing_index'));
@@ -1187,7 +1191,7 @@ class ZwaveDevice extends Homey.Device {
 
   /**
    * Method that flattens possibly nested settings and returns a flat settings array.
-   * @returns {Array}
+   * @returns {any[]}
    */
   getManifestSettings() {
     if (!this.manifestSettings) {
@@ -1212,8 +1216,8 @@ class ZwaveDevice extends Homey.Device {
 
   /**
    * Get a specific setting object from the manifest
-   * @param id - Setting id to retrieve
-   * @returns {Object|Error}
+   * @param {string} id - Setting id to retrieve
+   * @returns {object|Error}
    */
   getManifestSetting(id) {
     const settings = this.getManifestSettings();
@@ -1224,9 +1228,9 @@ class ZwaveDevice extends Homey.Device {
   /**
    * Method that refreshes the capability value once. If you want to poll this value please use
    * the parameter getOpts.pollInterval at {@link ZwaveDevice#registerCapability}
-   * @param {String} capabilityId, the string id of the Homey capability
-   * @param {String} commandClassId, the Z-Wave command class used for this request
-   * @returns {Promise<unknown>}
+   * @param {string} capabilityId - The string id of the Homey capability
+   * @param {string} commandClassId - The Z-Wave command class used for this request
+   * @returns {Promise<any>}
    */
   async refreshCapabilityValue(capabilityId, commandClassId) {
     return this._getCapabilityValue(capabilityId, commandClassId);
@@ -1433,8 +1437,9 @@ class ZwaveDevice extends Homey.Device {
 
   /**
    * Utility method to check if an object has a property.
-   * @param {*} object
-   * @param {*} prop
+   * @param {any} object
+   * @param {any} prop
+   * @private
    */
   _hasProp(object, prop) {
     return object && Object.prototype.hasOwnProperty.call(object, prop);

--- a/lib/ZwaveLightDevice.js
+++ b/lib/ZwaveLightDevice.js
@@ -7,6 +7,7 @@ const FACTORY_DEFAULT_COLOR_DURATION = 255;
 let debounceColorMode;
 
 /**
+ * @classdesc
  * ZwaveLightDevice takes care of all commands used by XY Lighting devices
  * (COMMAND_CLASS_SWITCH_COLOR). Set the capabilitiesOptions "setOnDim" to false for the onoff
  * capability
@@ -18,6 +19,7 @@ let debounceColorMode;
  * - light_temperature (SWITCH_COLOR >= V2)
  *
  * @extends ZwaveDevice
+ * @hideconstructor
  * @example
  *
  * // app.json
@@ -59,13 +61,11 @@ let debounceColorMode;
  * const ZwaveLightDevice = require('homey-meshdriver').ZwaveLightDevice;
  *
  * class myDevice extends ZwaveLightDevice {
- *
  *   async onNodeInit({ node }) {
- *
  *     await super.onNodeInit({ node });
  *     // YOUR CODE COMES HERE
- *     }
  *   }
+ * }
  */
 
 class ZwaveLightDevice extends ZwaveDevice {

--- a/lib/system/capabilities/target_temperature/THERMOSTAT_SETPOINT.js
+++ b/lib/system/capabilities/target_temperature/THERMOSTAT_SETPOINT.js
@@ -13,7 +13,7 @@ module.exports = {
   getParser() {
     return {
       Level: {
-        'Setpoint Type': this.thermostatSetpointType || 'Heating 1',
+        'Setpoint Type': this.thermostatSetpointType,
       },
     };
   },
@@ -25,7 +25,7 @@ module.exports = {
 
     return {
       Level: {
-        'Setpoint Type': this.thermostatSetpointType || 'Heating 1',
+        'Setpoint Type': this.thermostatSetpointType,
       },
       Level2: {
         Size: 2,

--- a/lib/util/color.js
+++ b/lib/util/color.js
@@ -41,14 +41,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-/**
- * Converts CIE color space to RGB color space
- * @param {Number} x
- * @param {Number} y
- * @param {Number} brightness - Ranges from 1 to 254
- * @return {Array} Array that contains the color values for red, green and blue
- * @ignore
- */
+// /**
+//  * Converts CIE color space to RGB color space
+//  * @param {number} x
+//  * @param {number} y
+//  * @param {number} brightness - Ranges from 1 to 254
+//  * @return {number[]} Array that contains the color values for red, green and blue
+//  * @ignore
+//  */
 // function cie_to_rgb(x, y, brightness) {
 //   // Set to maximum brightness if no custom value was given (Not the slick ECMAScript 6 way
 //   // for compatibility reasons)
@@ -110,10 +110,10 @@ THE SOFTWARE.
 
 /**
  * Converts RGB color space to CIE color space
- * @param {Number} red
- * @param {Number} green
- * @param {Number} blue
- * @return {Array} Array that contains the CIE color values for x and y
+ * @param {number} red
+ * @param {number} green
+ * @param {number} blue
+ * @return {number[]} Array that contains the CIE color values for x and y
  * @ignore
  */
 function rgbToCie(red, green, blue) {
@@ -144,29 +144,32 @@ function rgbToCie(red, green, blue) {
 }
 
 /**
- * @typedef {Object} RGB
+ * @typedef {object} RGB
  * @property {number} red - Red value, range 0 - 255.
  * @property {number} green - Green value, range 0 - 255.
  * @property {number} blue - Blue value, range 0 - 255.
+ * @memberof Util
  */
 
 /**
- * @typedef {Object} CIE
+ * @typedef {object} CIE
  * @property {number} x - CIE x (small x) value, range 0 - 0.8.
  * @property {number} y - CIE y (small y) value, range 0 - 0.9.
+ * @memberof Util
  */
 
 /**
- * @typedef {Object} HSV
+ * @typedef {object} HSV
  * @property {number} hue - Hue value, range 0 - 1.
  * @property {number} saturation - Saturation value, range 0 - 1.
  * @property {number} value - Value (brightness) value, range 0 - 1.
+ * @memberof Util
  */
 
 /**
  * Method that converts colors from the RGB color space to the CIE (1931) color space.
- * @param {RGB} - RGB color object
- * @returns {CIE|Error} - CIE color space object
+ * @param {Util.RGB} - RGB color object
+ * @returns {Util.CIE|Error} - CIE color space object
  * @memberof Util
  */
 function convertRGBToCIE({ red, green, blue }) {
@@ -186,8 +189,8 @@ function convertRGBToCIE({ red, green, blue }) {
 
 /**
  * Method that converts colors from the HSV (or HSL) color space to the RGB color space.
- * @param {HSV} - HSV color object
- * @returns {RGB} - RGB color object
+ * @param {Util.HSV} - HSV color object
+ * @returns {Util.RGB} - RGB color object
  * @memberof Util
  */
 function convertHSVToRGB({ hue, saturation, value }) {
@@ -201,8 +204,8 @@ function convertHSVToRGB({ hue, saturation, value }) {
 
 /**
  * Method that converts colors from the HSV (or HSL) color space to the CIE (1931) color space.
- * @param {HSV} - HSV color object
- * @returns {CIE|Error} - CIE color space object
+ * @param {Util.HSV} - HSV color object
+ * @returns {Util.CIE|Error} - CIE color space object
  * @memberof Util
  */
 function convertHSVToCIE({ hue, saturation, value }) {
@@ -216,8 +219,8 @@ function convertHSVToCIE({ hue, saturation, value }) {
 
 /**
  * Method that converts colors from the RGB color space to the HSV color space.
- * @param {RGB} - RGB color object
- * @returns {HSV} - HSV color object
+ * @param {Util.RGB} - RGB color object
+ * @returns {Util.HSV} - HSV color object
  * @memberof Util
  */
 function convertRGBToHSV({ red, green, blue }) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -6,7 +6,7 @@ const color = require('./color');
  * Allows accessing an object by a nested string path.
  * @param object
  * @param path
- * @returns {*}
+ * @returns {any}
  * @private
  *
  * @example
@@ -56,6 +56,7 @@ function mapValueRange(inputStart, inputEnd, outputStart, outputEnd, input) {
  * 1-127 = 1 second – 127 seconds
  * 128 – 253 = 1 minute – 126 minutes
  * 254 max
+ * @memberof Util
  */
 function calculateDimDuration(duration, opts = {}) {
   if (typeof duration !== 'number') {
@@ -73,7 +74,7 @@ function calculateDimDuration(duration, opts = {}) {
 }
 
 /**
- * @deprecated since v1.0.0 - Use {@link calculateDimDuration} instead.
+ * deprecated since v1.0.0 - Use {@link calculateDimDuration} instead.
  * @param {number} duration - Dim duration in milliseconds (0 - 7560000ms)
  * @param {object} opts
  * @param {number} opts.maxValue - Use a custom max value
@@ -81,6 +82,7 @@ function calculateDimDuration(duration, opts = {}) {
  * 1-127 = 1 second – 127 seconds
  * 128 – 253 = 1 minute – 126 minutes
  * 254 max
+ * @memberof Util
  */
 function calculateZwaveDimDuration(duration, opts = {}) {
   return calculateDimDuration(duration, opts);
@@ -133,8 +135,9 @@ function __(language, localeKey) {
 }
 
 /**
- * Utility class with several color and range conversion methods.
  * @class Util
+ * @classdesc Utility class with several color and range conversion methods.
+ * @hideconstructor
  */
 module.exports = {
   convertRGBToCIE: color.convertRGBToCIE,


### PR DESCRIPTION
I noticed some odd looking bits on https://athombv.github.io/node-homey-zwavedriver/ so I cleaned it up

- made all Utils `@memberof Util` so the "Global" section is not rendered. (not sure why global isn't clickable, seems to be a bug in the template)
- use `@hideconstructor` everywhere so we don't show `new ZwaveDevice()`, `new ZwaveLightDevice()` or `new Utils()`
- use lowercase for primitive types
- remove trailing commas from parameter names
- use `any` instead of `*`
- use `any` and instead of `object` where we are returning/handing it to user code
- Promise and Array are generic and should receive a type parameter
- `@deprecated` doesn't seem to work in the jsdoc template so I removed it