### PR TITLE
feat: exclude sending duration from polling duration

### DIFF
--- a/lib/ZwaveDevice.js
+++ b/lib/ZwaveDevice.js
@@ -83,11 +83,11 @@ class ZwaveDevice extends Homey.Device {
     this._capabilities = {};
     this._settings = {};
     this._reportListeners = {};
+
     this._pollIntervals = {};
     this._pollIntervalsKeys = {};
 
     this._debugEnabled = false;
-    this._pollIntervals = {};
 
     // Bind __ with current language
     this.zwavedriverI18n = __.bind(this, this.homey.i18n.getLanguage());
@@ -411,15 +411,21 @@ class ZwaveDevice extends Homey.Device {
     this._pollIntervals[capabilityId] = this._pollIntervals[capabilityId] || {};
 
     if (this._pollIntervals[capabilityId][commandClassId]) {
-      clearInterval(this._pollIntervals[capabilityId][commandClassId]);
+      clearTimeout(this._pollIntervals[capabilityId][commandClassId]);
     }
 
     if (pollInterval < 1) return;
 
-    this._pollIntervals[capabilityId][commandClassId] = setInterval(() => {
-      this._debug(`Polling commandClassId '${commandClassId}' for capabilityId '${capabilityId}'`);
-      this._getCapabilityValue(capabilityId, commandClassId).catch(err => this.error(`Could not get capability value for capabilityId: ${capabilityId}`, err));
-    }, pollInterval);
+    const nextPoll = () => {
+      this._pollIntervals[capabilityId][commandClassId] = setTimeout(() => {
+        this._debug(`Polling commandClassId '${commandClassId}' for capabilityId '${capabilityId}'`);
+        this._getCapabilityValue(capabilityId, commandClassId)
+          .catch(err => this.error(`Could not get capability value for capabilityId: ${capabilityId}`, err))
+          .finally(() => nextPoll());
+      }, pollInterval);
+    };
+
+    nextPoll();
   }
 
   /**


### PR DESCRIPTION
Some apps appear to be queuing messages more quickly than we can send them.
We need a fix for this internally but we can improve the behaviour zwavedriver by waiting until the request is settled before we start the next poll interval.