### PR TITLE
#patch release 2.1.5

### DIFF
--- a/lib/ZwaveDevice.js
+++ b/lib/ZwaveDevice.js
@@ -84,8 +84,8 @@ class ZwaveDevice extends Homey.Device {
     this._settings = {};
     this._reportListeners = {};
 
-    this._pollIntervals = {};
-    this._pollIntervalsKeys = {};
+    this._pollTimeouts = {};
+    this._pollIntervalSettingKeys = {};
 
     this._debugEnabled = false;
 
@@ -114,7 +114,7 @@ class ZwaveDevice extends Homey.Device {
   }
 
   /**
-   * Remove all listeners and intervals from node
+   * Remove all listeners and timeouts from node
    */
   onDeleted() {
     if (!this.node) return;
@@ -122,12 +122,12 @@ class ZwaveDevice extends Homey.Device {
     // Remove listeners on node
     if (this.node) this.node.removeAllListeners();
 
-    // Clear all pollIntervals
-    if (this._pollIntervals) {
+    // Clear all pollTimeouts
+    if (this._pollTimeouts) {
       // Sometimes it is null/undefined for some reason
-      Object.keys(this._pollIntervals).forEach(capabilityId => {
-        Object.values(this._pollIntervals[capabilityId]).forEach(interval => {
-          clearInterval(interval);
+      Object.keys(this._pollTimeouts).forEach(capabilityId => {
+        Object.values(this._pollTimeouts[capabilityId]).forEach(timeout => {
+          this.homey.clearTimeout(timeout);
         });
       });
     }
@@ -170,19 +170,19 @@ class ZwaveDevice extends Homey.Device {
     for (const changedKey of changedKeys) {
       const newValue = newSettings[changedKey];
 
-      // check for poll interval
-      if (this._pollIntervalsKeys[changedKey]) {
+      // check for polling settings
+      if (this._pollIntervalSettingKeys[changedKey]) {
         const capabilityGetObj = this._getCapabilityObj(
           'get',
-          this._pollIntervalsKeys[changedKey].capabilityId,
-          this._pollIntervalsKeys[changedKey].commandClassId,
+          this._pollIntervalSettingKeys[changedKey].capabilityId,
+          this._pollIntervalSettingKeys[changedKey].commandClassId,
         );
         const pollMultiplication = capabilityGetObj.opts.pollMultiplication || 1;
         const pollInterval = newValue * pollMultiplication;
 
         this._setPollInterval(
-          this._pollIntervalsKeys[changedKey].capabilityId,
-          this._pollIntervalsKeys[changedKey].commandClassId,
+          this._pollIntervalSettingKeys[changedKey].capabilityId,
+          this._pollIntervalSettingKeys[changedKey].commandClassId,
           pollInterval,
         );
         continue;
@@ -390,7 +390,7 @@ class ZwaveDevice extends Homey.Device {
 
       if (typeof capabilityGetObj.opts.pollInterval === 'string') {
         pollInterval = this.getSetting(capabilityGetObj.opts.pollInterval) * pollMultiplication;
-        this._pollIntervalsKeys[capabilityGetObj.opts.pollInterval] = {
+        this._pollIntervalSettingKeys[capabilityGetObj.opts.pollInterval] = {
           capabilityId,
           commandClassId,
         };
@@ -404,16 +404,16 @@ class ZwaveDevice extends Homey.Device {
    * @private
    */
   _setPollInterval(capabilityId, commandClassId, pollInterval) {
-    this._pollIntervals[capabilityId] = this._pollIntervals[capabilityId] || {};
+    this._pollTimeouts[capabilityId] = this._pollTimeouts[capabilityId] || {};
 
-    if (this._pollIntervals[capabilityId][commandClassId]) {
-      clearTimeout(this._pollIntervals[capabilityId][commandClassId]);
+    if (this._pollTimeouts[capabilityId][commandClassId]) {
+      this.homey.clearTimeout(this._pollTimeouts[capabilityId][commandClassId]);
     }
 
     if (pollInterval < 1) return;
 
     const nextPoll = () => {
-      this._pollIntervals[capabilityId][commandClassId] = setTimeout(() => {
+      this._pollTimeouts[capabilityId][commandClassId] = this.homey.setTimeout(() => {
         this._debug(`Polling commandClassId '${commandClassId}' for capabilityId '${capabilityId}'`);
         this._getCapabilityValue(capabilityId, commandClassId)
           .catch(err => this.error(`Could not get capability value for capabilityId: ${capabilityId}`, err))


### PR DESCRIPTION
Changelog

- do not replace errors with translated string
- polling interval excludes command duration