### PR TITLE
fix: cc basic onoff type

### DIFF
--- a/lib/system/capabilities/onoff/BASIC.js
+++ b/lib/system/capabilities/onoff/BASIC.js
@@ -9,17 +9,13 @@ module.exports = {
   report: 'BASIC_REPORT',
   reportParserV1(report) {
     if (report && report.hasOwnProperty('Value')) {
-      if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', report['Value'] > 0);
-      if (report['Value'] > 99) return 1;
-      return report['Value'] / 99;
+      return report['Value'] > 0;
     }
     return null;
   },
   reportParserV2(report) {
     if (report && report.hasOwnProperty('Current Value')) {
-      if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', report['Current Value'] > 0);
-      if (report['Current Value'] > 99) return 1;
-      return report['Current Value'] / 99;
+      return report['Current Value'] > 0;
     }
     return null;
   },


### PR DESCRIPTION
Copy pasta error in this commit: https://github.com/athombv/node-homey-zwavedriver/commit/84223ef1f1b9df6bbf22cb456e7db67a323aa217

It works since we check `hasCapability` but causes errors because its returning the wrong type.