### PR TITLE
Update METER payload parser (index.js)

### DIFF
--- a/lib/system/commandclasses/METER/index.js
+++ b/lib/system/commandclasses/METER/index.js
@@ -54,8 +54,8 @@ module.exports = payload => {
     }
   }
 
-  const size = properties2['Size'];
-  const precision = properties2['Precision'];
+  const size = properties1['Size'] || properties2['Size'];
+  const precision = properties1['Precision'] || properties2['Precision'];
 
   const meterValue = payload['Meter Value'];
   const previousMeterValue = payload['Previous Meter Value'];


### PR DESCRIPTION
If a METER v6 is used without "previous meter value" (4x `0x00`) it will be determined by the core parser as a METER v2, which has the "precision" and "scale" in `properties1` instead of `properties2` failing the payload parser. This fix is necessary to get the new Shelly Qubino devices METER reporting working.