### PR TITLE
CommandClass meter v6 reset implementation

### DIFF
--- a/lib/ZwaveDevice.js
+++ b/lib/ZwaveDevice.js
@@ -1059,13 +1059,15 @@ class ZwaveDevice extends Homey.Device {
     }
 
     if (commandClassMeter && commandClassMeter.hasOwnProperty('METER_RESET')) {
-      if (commandClassMeter.version < 6 && options.length > 0) {
-        throw new Error('invalid_meter_reset_options');
+      if (commandClassMeter.version < 6) {
+        if (options.length > 0) {
+          throw new Error('invalid_meter_reset_options');
+        }
       } else {
         options = {
           Properties1: {
             'Scale bit 2': false,
-            'Rate Type': 2,
+            'Rate Type': 0,
             'Meter Type': 'Electric meter',
           },
           Properties2: {

--- a/lib/ZwaveDevice.js
+++ b/lib/ZwaveDevice.js
@@ -1045,11 +1045,15 @@ class ZwaveDevice extends Homey.Device {
   /**
    * Method that resets the accumulated power meter value on the node. It tries to find the root
    * node of the device and then looks for the COMMAND_CLASS_METER.
+   * In case of a CommandClass version >= 6, the options object will be provided to set which meter
+   * needs to be reset and to what value. By default it resets the kWh meter to 0.
+   *
    * @param multiChannelNodeId - define the multi channel node id in case the
    * COMMAND_CLASS_METER is on a multi channel node.
+   * @param options - options given to the METER_RESET command, Only used when version >= 6
    * @returns {Promise<any>}
    */
-  async meterReset({ multiChannelNodeId } = {}, { options } = {}) {
+  async meterReset({ multiChannelNodeId } = {}, options = {}) {
     // Get command class object (on mc node if needed)
     let commandClassMeter = null;
     if (typeof multiChannelNodeId === 'number') {
@@ -1059,11 +1063,7 @@ class ZwaveDevice extends Homey.Device {
     }
 
     if (commandClassMeter && commandClassMeter.hasOwnProperty('METER_RESET')) {
-      if (commandClassMeter.version < 6) {
-        if (options.length > 0) {
-          throw new Error('invalid_meter_reset_options');
-        }
-      } else {
+      if (commandClassMeter.version >= 6 && Object.keys(options).length === 0) {
         options = {
           Properties1: {
             'Scale bit 2': false,
@@ -1077,7 +1077,6 @@ class ZwaveDevice extends Homey.Device {
           },
           'Meter Value': Buffer.from([0]),
           'Scale 2': 0,
-          ...options,
         };
       }
       const result = await commandClassMeter.METER_RESET(options);

--- a/lib/ZwaveDevice.js
+++ b/lib/ZwaveDevice.js
@@ -1049,7 +1049,7 @@ class ZwaveDevice extends Homey.Device {
    * COMMAND_CLASS_METER is on a multi channel node.
    * @returns {Promise<any>}
    */
-  async meterReset({ multiChannelNodeId } = {}) {
+  async meterReset({ multiChannelNodeId } = {}, { options } = {}) {
     // Get command class object (on mc node if needed)
     let commandClassMeter = null;
     if (typeof multiChannelNodeId === 'number') {
@@ -1059,7 +1059,26 @@ class ZwaveDevice extends Homey.Device {
     }
 
     if (commandClassMeter && commandClassMeter.hasOwnProperty('METER_RESET')) {
-      const result = await commandClassMeter.METER_RESET({});
+      if (commandClassMeter.version < 6 && options.length > 0) {
+        throw new Error('invalid_meter_reset_options');
+      } else {
+        options = {
+          Properties1: {
+            'Scale bit 2': false,
+            'Rate Type': 2,
+            'Meter Type': 'Electric meter',
+          },
+          Properties2: {
+            Size: 1,
+            'Scale bits 10': 0,
+            Precision: 0,
+          },
+          'Meter Value': Buffer.from([0]),
+          'Scale 2': 0,
+          ...options,
+        };
+      }
+      const result = await commandClassMeter.METER_RESET(options);
       if (result !== 'TRANSMIT_COMPLETE_OK') throw result;
 
       // Return if reset was successful


### PR DESCRIPTION
Reason:
Command class meter V6 requires the METER_RESET command to have properties defining which meter to reset and to which value. These were not present in the implementation of `meterReset()` 

Changes:
- Define default properties to reset the kWh properties of the Z-Wave device
- Allow for the option te redefine the properties 
- Do not set this option if the command class is not version 6

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205934390749176